### PR TITLE
Refactors history file format for torrent types

### DIFF
--- a/Daily Report/parsed_movies_history.csv
+++ b/Daily Report/parsed_movies_history.csv
@@ -1,504 +1,506 @@
-﻿href,phase,video_code,create_date,update_date,torrent_type
-/v/kKybem,2,MFYD-021,2025-07-11 20:05:34,2025-07-12 20:09:36,"hacked_no_subtitle,no_subtitle"
-/v/kKyZ16,2,HNDS-182,2025-07-12 20:07:30,2025-07-12 20:07:30,no_subtitle
-/v/mOJ2Gv,2,MIDA-237,2025-07-12 20:07:01,2025-07-12 20:07:01,no_subtitle
-/v/6dqWE7,2,MIAB-501,2025-07-12 16:29:46,2025-07-12 20:06:06,"hacked_no_subtitle,no_subtitle"
-/v/qAJ21e,2,MIDA-238,2025-07-12 20:05:48,2025-07-12 20:05:48,no_subtitle
-/v/ZNdwYm,2,FPRE-190,2025-07-12 20:05:36,2025-07-12 20:05:36,no_subtitle
-/v/ZNdObq,2,HUBLK-056,2025-07-12 20:05:03,2025-07-12 20:05:03,no_subtitle
-/v/DRV7DM,2,MFYD-028,2025-07-12 16:33:41,2025-07-12 16:33:41,no_subtitle
-/v/kKy8AN,2,EYAN-203,2025-07-12 16:33:35,2025-07-12 16:33:35,no_subtitle
-/v/Xe4d5G,2,NHDTC-078,2025-07-12 16:33:11,2025-07-12 16:33:11,no_subtitle
-/v/AqK7ge,2,PPPE-362,2025-07-12 16:32:53,2025-07-12 16:32:53,no_subtitle
-/v/YwrB8p,2,MIDA-228,2025-07-12 16:32:47,2025-07-12 16:32:47,no_subtitle
-/v/Mbqp9k,2,MIDA-244,2025-07-12 16:32:40,2025-07-12 16:32:40,no_subtitle
-/v/mOJvM5,2,HMN-720,2025-07-12 16:32:28,2025-07-12 16:32:28,no_subtitle
-/v/0edXEa,2,HJMO-685,2025-07-12 16:32:22,2025-07-12 16:32:22,no_subtitle
-/v/Rk2RpD,2,MIDA-248,2025-07-12 16:32:15,2025-07-12 16:32:15,no_subtitle
-/v/96qm2X,2,MIDA-235,2025-07-12 16:32:03,2025-07-12 16:32:03,no_subtitle
-/v/mOJWxY,2,MIKR-026,2025-07-12 16:31:57,2025-07-12 16:31:57,no_subtitle
-/v/YwrdDD,2,MFYD-024,2025-07-12 16:31:45,2025-07-12 16:31:45,no_subtitle
-/v/Rk2m0m,2,PPPE-355,2025-07-12 16:31:33,2025-07-12 16:31:33,no_subtitle
-/v/MbqMAv,2,FPRE-185,2025-07-12 16:31:27,2025-07-12 16:31:27,no_subtitle
-/v/ZNdw9m,2,PRED-783,2025-07-12 16:31:20,2025-07-12 16:31:20,no_subtitle
-/v/V4NWRQ,2,VENX-328,2025-07-12 16:31:08,2025-07-12 16:31:08,no_subtitle
-/v/4Dd3J3,2,MFYD-029,2025-07-12 16:31:02,2025-07-12 16:31:02,no_subtitle
-/v/pkqdYZ,2,PRED-782,2025-07-12 16:30:55,2025-07-12 16:30:55,no_subtitle
-/v/82qAg3,2,MIDA-240,2025-07-12 16:30:49,2025-07-12 16:30:49,no_subtitle
-/v/82q785,2,PPPE-351,2025-07-12 16:30:42,2025-07-12 16:30:42,no_subtitle
-/v/Eb67Dx,2,MIAB-506,2025-07-12 16:30:36,2025-07-12 16:30:36,no_subtitle
-/v/e8OMYN,2,FPRE-186,2025-07-12 16:30:29,2025-07-12 16:30:29,no_subtitle
-/v/MbqpPk,2,PRED-790,2025-07-12 16:30:12,2025-07-12 16:30:12,no_subtitle
-/v/0ed7ZX,2,PRED-786,2025-07-12 16:30:05,2025-07-12 16:30:05,no_subtitle
-/v/MbqMyv,2,PRED-781,2025-07-12 16:29:59,2025-07-12 16:29:59,no_subtitle
-/v/0edA3q,2,JUR-443,2025-07-05 22:10:23,2025-07-12 16:29:52,"hacked_subtitle,no_subtitle"
-/v/a8yv1g,2,MFYD-030,2025-07-12 16:29:28,2025-07-12 16:29:28,no_subtitle
-/v/yx4Q3b,2,FPRE-187,2025-07-12 16:29:22,2025-07-12 16:29:22,no_subtitle
-/v/BzgwO6,2,EBWH-242,2025-07-12 16:29:15,2025-07-12 16:29:15,no_subtitle
-/v/YwrB8B,2,PRED-784,2025-07-12 16:29:09,2025-07-12 16:29:09,no_subtitle
-/v/kKyzd0,1,JUR-436,2025-07-06 21:00:06,2025-07-12 16:26:40,"no_subtitle,subtitle"
-/v/AqKpGm,1,JUR-430,2025-07-12 16:26:33,2025-07-12 16:26:33,subtitle
-/v/Rk2rnn,1,JUR-414,2025-07-05 22:10:48,2025-07-12 16:26:27,"hacked_subtitle,no_subtitle,subtitle"
-/v/ve0kKp,1,JUFE-591,2025-06-29 22:30:59,2025-07-12 16:26:20,"no_subtitle,subtitle"
-/v/V4NMMW,1,JRZE-249,2025-07-12 16:26:14,2025-07-12 16:26:14,subtitle
-/v/96q27q,1,JRZE-246,2025-07-12 16:26:07,2025-07-12 16:26:07,subtitle
-/v/82qYp3,1,IPZZ-613,2025-07-05 22:11:31,2025-07-12 16:26:01,"hacked_subtitle,no_subtitle,subtitle"
-/v/NQPOVG,1,IPZZ-605,2025-07-05 22:11:34,2025-07-12 16:25:54,"no_subtitle,subtitle"
-/v/xAgmyQ,1,IPSE-016,2025-07-12 16:25:48,2025-07-12 16:25:48,subtitle
-/v/GZ4BvJ,1,IPSE-013,2025-07-12 16:25:42,2025-07-12 16:25:42,subtitle
-/v/6dqPVZ,1,DASS-692,2025-07-12 16:25:35,2025-07-12 16:25:35,subtitle
-/v/Eb6NY9,1,DASS-690,2025-07-12 16:25:29,2025-07-12 16:25:29,subtitle
-/v/d4nW89,1,MIDV-316,2025-07-12 16:25:22,2025-07-12 16:25:22,"hacked_no_subtitle,subtitle"
-/v/XWxXde,1,MIDV-305,2025-07-12 16:25:16,2025-07-12 16:25:16,"hacked_subtitle,no_subtitle"
-/v/wq0abe,1,MIDV-290,2025-07-12 16:25:09,2025-07-12 16:25:09,"hacked_no_subtitle,subtitle"
-/v/yrAaQg,1,MIDV-278,2025-07-12 16:25:03,2025-07-12 16:25:03,"hacked_subtitle,subtitle"
-/v/akKE7q,1,MIDV-267,2025-07-12 16:24:56,2025-07-12 16:24:56,"hacked_subtitle,subtitle"
-/v/wKkgkz,1,MIDA-204,2025-07-12 16:24:50,2025-07-12 16:24:50,"hacked_no_subtitle,subtitle"
-/v/gyqQqG,1,MIDA-201,2025-07-12 16:24:43,2025-07-12 16:24:43,"hacked_subtitle,subtitle"
-/v/ZNdp6X,1,MIDA-194,2025-07-12 16:24:37,2025-07-12 16:24:37,"hacked_no_subtitle,subtitle"
-/v/5nXbBa,1,MIAB-502,2025-07-12 16:24:30,2025-07-12 16:24:30,"hacked_no_subtitle,subtitle"
-/v/J06YEq,2,MOON-044,2025-07-11 20:06:49,2025-07-11 20:06:49,no_subtitle
-/v/P92AEr,2,HBAD-713,2025-07-11 20:06:31,2025-07-11 20:06:31,no_subtitle
-/v/ve02vk,2,MNGS-007,2025-07-11 20:06:25,2025-07-11 20:06:25,no_subtitle
-/v/WwVZOZ,2,SIRO-5488,2025-07-11 20:06:13,2025-07-11 20:06:13,no_subtitle
-/v/kKy29V,2,MIDA-242,2025-07-11 20:06:06,2025-07-11 20:06:06,no_subtitle
-/v/r3YRvJ,2,HMN-712,2025-07-11 20:06:00,2025-07-11 20:06:00,no_subtitle
-/v/kKy8aN,2,MIMK-200,2025-07-11 20:05:53,2025-07-11 20:05:53,no_subtitle
-/v/AqKB2O,2,MIKR-028,2025-07-11 20:05:47,2025-07-11 20:05:47,no_subtitle
-/v/ZNdw9V,2,MIDA-198,2025-07-11 20:05:40,2025-07-11 20:05:40,no_subtitle
-/v/DRVgm3,2,ABF-247,2025-07-11 20:05:27,2025-07-11 20:05:27,no_subtitle
-/v/a8yQXr,2,ABF-246,2025-07-11 20:05:21,2025-07-11 20:05:21,no_subtitle
-/v/Mbq9GR,2,KBR-027,2025-07-11 20:05:14,2025-07-11 20:05:14,no_subtitle
-/v/YwrdXb,2,MNGS-006,2025-07-11 20:05:08,2025-07-11 20:05:08,no_subtitle
-/v/AqK7Oe,2,MIDA-241,2025-07-11 20:05:01,2025-07-11 20:05:01,no_subtitle
-/v/WwVNmq,2,MIDA-234,2025-07-11 20:04:55,2025-07-11 20:04:55,no_subtitle
-/v/7yq7OP,2,MIMK-217,2025-07-11 20:04:48,2025-07-11 20:04:48,no_subtitle
-/v/kKy2nV,2,PRED-785,2025-07-11 20:04:42,2025-07-11 20:04:42,no_subtitle
-/v/DRVG82,1,SONE-790,2025-07-05 22:10:13,2025-07-11 20:02:34,"hacked_subtitle,no_subtitle,subtitle"
-/v/mOJWnD,1,SONE-746,2025-07-05 22:10:47,2025-07-11 20:02:28,"hacked_subtitle,no_subtitle,subtitle"
-/v/mOJqwZ,1,JUR-415,2025-07-11 20:02:21,2025-07-11 20:02:21,subtitle
-/v/a8yNqp,1,JUR-407,2025-07-05 22:11:29,2025-07-11 20:02:09,"no_subtitle,subtitle"
-/v/4Dd98p,1,JUR-400,2025-07-11 20:02:02,2025-07-11 20:02:02,subtitle
-/v/DRVkWa,1,JUR-397,2025-07-06 21:00:13,2025-07-11 20:01:55,"no_subtitle,subtitle"
-/v/ve0xOG,1,JUR-395,2025-07-11 20:01:49,2025-07-11 20:01:49,subtitle
-/v/YwrkZd,1,JUR-380,2025-07-09 20:05:05,2025-07-11 20:01:43,"hacked_subtitle,no_subtitle,subtitle"
-/v/ZNdApJ,1,JUR-370,2025-07-05 22:10:31,2025-07-11 20:01:36,"hacked_subtitle,no_subtitle,subtitle"
-/v/pkqXOB,1,JUR-364,2025-07-06 21:00:37,2025-07-11 20:01:30,"no_subtitle,subtitle"
-/v/kKyz36,1,JUR-333,2025-07-06 21:02:22,2025-07-11 20:01:23,"no_subtitle,subtitle"
-/v/mOJqy5,1,JUR-047,2025-07-05 22:11:26,2025-07-11 20:01:17,"no_subtitle,subtitle"
-/v/WwVrrQ,1,MFYD-011,2025-07-11 20:01:10,2025-07-11 20:01:10,"hacked_no_subtitle,subtitle"
-/v/veZydn,1,MEYD-998,2025-07-11 20:01:04,2025-07-11 20:01:04,"hacked_no_subtitle,subtitle"
-/v/qDx13,1,MEYD-280,2025-07-11 20:00:57,2025-07-11 20:00:57,"hacked_no_subtitle,subtitle"
-/v/Bzg969,2,GVH-757,2025-07-10 20:06:00,2025-07-10 20:06:00,no_subtitle
-/v/ZNdJ5P,2,AKDL-331,2025-07-10 20:05:48,2025-07-10 20:05:48,no_subtitle
-/v/pkqev9,2,GNSZ-001,2025-07-10 20:05:41,2025-07-10 20:05:41,no_subtitle
-/v/AqK23y,2,PJAB-012,2025-07-10 20:05:35,2025-07-10 20:05:35,no_subtitle
-/v/pkqeeq,2,MANX-014,2025-07-10 00:02:35,2025-07-10 20:05:17,"hacked_no_subtitle,no_subtitle"
-/v/JrQeq,2,KNAM-056,2025-07-10 20:05:11,2025-07-10 20:05:11,"hacked_no_subtitle,no_subtitle"
-/v/ZNd9bX,2,JUVR-234,2025-07-10 00:02:29,2025-07-10 20:05:04,"hacked_no_subtitle,no_subtitle"
-/v/96qAvX,2,MFCS-172,2025-07-10 20:04:58,2025-07-10 20:04:58,no_subtitle
-/v/1A45yn,2,DAM-057,2025-07-10 20:04:41,2025-07-10 20:04:41,no_subtitle
-/v/YwrppB,2,START-347,2025-07-10 20:04:34,2025-07-10 20:04:34,no_subtitle
-/v/DRVp4p,2,MIUM-1256,2025-07-10 20:04:28,2025-07-10 20:04:28,no_subtitle
-/v/pkxpvw,2,MDVR-344,2025-07-10 20:04:16,2025-07-10 20:04:16,hacked_no_subtitle
-/v/xAgmKn,1,SONE-812,2025-07-10 20:02:20,2025-07-10 20:02:20,subtitle
-/v/82qAYV,1,SONE-808,2025-07-06 21:00:25,2025-07-10 20:02:13,"no_subtitle,subtitle"
-/v/96qmZ6,1,SONE-807,2025-07-05 22:10:35,2025-07-10 20:02:07,"no_subtitle,subtitle"
-/v/kKy87e,1,SONE-793,2025-07-05 22:10:32,2025-07-10 20:02:00,"hacked_subtitle,no_subtitle,subtitle"
-/v/YwrOPe,1,SONE-758,2025-07-09 23:58:59,2025-07-10 20:01:47,"hacked_subtitle,subtitle"
-/v/AqKB8n,1,SONE-753,2025-07-10 20:01:41,2025-07-10 20:01:41,subtitle
-/v/AqK8WO,1,IPZZ-647,2025-07-10 20:01:28,2025-07-10 20:01:28,subtitle
-/v/Rk21OD,1,IPZZ-615,2025-07-10 20:01:21,2025-07-10 20:01:21,subtitle
-/v/GZ4By5,1,IPZZ-607,2025-07-05 22:10:53,2025-07-10 20:01:08,"no_subtitle,subtitle"
-/v/gyqndG,1,IPZZ-599,2025-07-09 23:58:33,2025-07-10 20:01:02,"hacked_subtitle,subtitle"
-/v/MbqkvQ,2,JAC-218,2025-07-10 00:02:48,2025-07-10 00:02:48,no_subtitle
-/v/BzgBWO,2,MFCW-053,2025-07-10 00:02:23,2025-07-10 00:02:23,no_subtitle
-/v/kKyNkJ,2,AKDL-332,2025-07-10 00:02:16,2025-07-10 00:02:16,no_subtitle
-/v/WwVNeQ,1,SONE-805,2025-07-09 23:59:25,2025-07-09 23:59:25,subtitle
-/v/a8yn0X,1,SONE-804,2025-07-09 23:59:19,2025-07-09 23:59:19,subtitle
-/v/4DdP2b,1,SONE-798,2025-07-09 23:59:12,2025-07-09 23:59:12,subtitle
-/v/0edX1J,1,SONE-795,2025-07-09 23:59:06,2025-07-09 23:59:06,subtitle
-/v/degnW0,1,IPZZ-604,2025-07-09 23:58:53,2025-07-09 23:58:53,subtitle
-/v/Bzg9G6,1,IPZZ-602,2025-07-09 23:58:46,2025-07-09 23:58:46,subtitle
-/v/wKkAPz,1,IPZZ-601,2025-07-09 23:58:40,2025-07-09 23:58:40,subtitle
-/v/3nrDY9,1,IPZZ-575,2025-07-09 23:58:26,2025-07-09 23:58:26,"hacked_subtitle,subtitle"
-/v/mOJnXY,1,IPZZ-574,2025-07-09 23:58:20,2025-07-09 23:58:20,"hacked_subtitle,subtitle"
-/v/96qBv8,2,NGOD-272,2025-07-08 20:06:00,2025-07-08 20:06:00,no_subtitle
-/v/z458vJ,2,APGH-039,2025-07-08 20:05:24,2025-07-08 20:05:24,no_subtitle
-/v/a8ynA3,2,LULU-384,2025-07-08 20:05:18,2025-07-08 20:05:18,no_subtitle
-/v/Ywrbxb,2,FLAV-398,2025-07-08 20:05:11,2025-07-08 20:05:11,no_subtitle
-/v/z450kQ,2,SIRO-5499,2025-07-08 20:05:05,2025-07-08 20:05:05,no_subtitle
-/v/ne4aA9,1,MIDV-247,2025-07-08 20:02:58,2025-07-08 20:02:58,"hacked_subtitle,subtitle"
-/v/RdJmPD,1,MIDV-228,2025-07-08 20:02:51,2025-07-08 20:02:51,"hacked_subtitle,subtitle"
-/v/XWqb01,1,MIDV-206,2025-07-08 20:02:45,2025-07-08 20:02:45,"hacked_subtitle,subtitle"
-/v/DR4Jp3,1,FTHTD-094,2025-07-08 20:02:38,2025-07-08 20:02:38,subtitle
-/v/xAgmwB,1,FPRE-184,2025-07-08 20:02:32,2025-07-08 20:02:32,subtitle
-/v/NQPOqx,1,FPRE-183,2025-07-08 20:02:26,2025-07-08 20:02:26,subtitle
-/v/a8ypZX,1,FOCS-257,2025-07-08 20:02:19,2025-07-08 20:02:19,subtitle
-/v/V4NpVD,1,FERA-200,2025-07-08 20:02:13,2025-07-08 20:02:13,subtitle
-/v/Rk2Jv4,1,EUUD-067,2025-07-08 20:02:06,2025-07-08 20:02:06,subtitle
-/v/xAgN9P,1,EUUD-066,2025-07-08 20:02:00,2025-07-08 20:02:00,subtitle
-/v/BzKNP1,1,EUUD-065,2025-07-08 20:01:53,2025-07-08 20:01:53,subtitle
-/v/xAgmO6,1,DVEH-056,2025-07-08 20:01:47,2025-07-08 20:01:47,subtitle
-/v/wKpWke,1,DVEH-054,2025-07-08 20:01:41,2025-07-08 20:01:41,subtitle
-/v/82X7Z3,1,JUR-197,2025-07-08 20:01:34,2025-07-08 20:01:34,"hacked_subtitle,subtitle"
-/v/XzOrG,1,JUL-300,2025-07-08 20:01:28,2025-07-08 20:01:28,"hacked_no_subtitle,subtitle"
-/v/mbRwD,1,JUL-142,2025-07-08 20:01:21,2025-07-08 20:01:21,"hacked_no_subtitle,subtitle"
-/v/XeqeGJ,1,JUFE-583,2025-07-08 20:01:15,2025-07-08 20:01:15,"hacked_no_subtitle,subtitle"
-/v/KeV6,1,IPZ-826,2025-07-08 20:01:08,2025-07-08 20:01:08,"hacked_subtitle,subtitle"
-/v/bNWA,1,IPZ-700,2025-07-08 20:01:02,2025-07-08 20:01:02,"hacked_no_subtitle,subtitle"
-/v/J00yx,1,IPZ-166,2025-07-08 20:00:55,2025-07-08 20:00:55,"hacked_no_subtitle,subtitle"
-/v/6dqGZ0,2,MKMP-650,2025-07-07 20:05:45,2025-07-07 20:05:45,no_subtitle
-/v/J06Yg8,2,ROE-386,2025-07-07 20:05:27,2025-07-07 20:05:27,no_subtitle
-/v/p33M9,2,HBAD-338,2025-07-07 20:05:21,2025-07-07 20:05:21,"hacked_no_subtitle,no_subtitle"
-/v/wKkaRB,2,DOKS-641,2025-07-07 20:05:03,2025-07-07 20:05:03,no_subtitle
-/v/mOJk9v,2,MDVR-351,2025-07-07 20:04:51,2025-07-07 20:04:51,no_subtitle
-/v/G8dAb,2,HZGD-175,2025-07-07 20:04:34,2025-07-07 20:04:34,"hacked_no_subtitle,no_subtitle"
-/v/Mbq8gA,2,HMN-708,2025-07-07 20:04:27,2025-07-07 20:04:27,"hacked_no_subtitle,no_subtitle"
-/v/wKkAr1,1,WAAA-543,2025-07-07 20:02:09,2025-07-07 20:02:09,subtitle
-/v/yx4RbZ,1,WAAA-542,2025-07-07 20:02:02,2025-07-07 20:02:02,subtitle
-/v/gyqnME,1,WAAA-541,2025-07-07 20:01:56,2025-07-07 20:01:56,subtitle
-/v/r3YZdJ,1,WAAA-539,2025-07-07 20:01:49,2025-07-07 20:01:49,subtitle
-/v/NQPOnN,1,WAAA-537,2025-07-07 20:01:43,2025-07-07 20:01:43,subtitle
-/v/degn8M,1,WAAA-536,2025-07-07 20:01:36,2025-07-07 20:01:36,subtitle
-/v/YwrO3p,1,WAAA-511,2025-07-07 20:01:30,2025-07-07 20:01:30,"hacked_subtitle,subtitle"
-/v/yx4RPZ,1,VENX-326,2025-07-07 20:01:23,2025-07-07 20:01:23,subtitle
-/v/7yqdPB,1,VENX-325,2025-07-07 20:01:17,2025-07-07 20:01:17,subtitle
-/v/2d3zy,1,IPX-899,2025-07-07 20:01:10,2025-07-07 20:01:10,"hacked_no_subtitle,subtitle"
-/v/W5bn8,1,IPX-793,2025-07-07 20:01:04,2025-07-07 20:01:04,"hacked_no_subtitle,subtitle"
-/v/yVgJg,1,IPIT-024,2025-07-07 20:00:57,2025-07-07 20:00:57,"hacked_no_subtitle,subtitle"
-/v/AqK13n,2,START-345,2025-07-06 21:05:19,2025-07-06 21:05:19,no_subtitle
-/v/96q3DV,2,DLDSS-406,2025-07-06 21:04:56,2025-07-06 21:04:56,no_subtitle
-/v/nKz6ee,2,MGOLD-037,2025-07-06 21:04:50,2025-07-06 21:04:50,no_subtitle
-/v/mOJqAR,2,NGOD-275,2025-07-06 21:04:21,2025-07-06 21:04:21,no_subtitle
-/v/a8yQ5r,2,DRPT-091,2025-07-06 21:04:15,2025-07-06 21:04:15,no_subtitle
-/v/z45Y8J,2,ROE-377,2025-07-06 21:04:03,2025-07-06 21:04:03,no_subtitle
-/v/1A4OBJ,2,FNS-077,2025-07-06 21:03:21,2025-07-06 21:03:21,"hacked_no_subtitle,no_subtitle"
-/v/1A4m8w,2,JUR-396,2025-07-06 21:02:45,2025-07-06 21:02:45,no_subtitle
-/v/a8ynOX,2,DASS-679,2025-07-06 21:01:54,2025-07-06 21:01:54,no_subtitle
-/v/bKw2kB,2,AVSA-388,2025-07-06 21:01:42,2025-07-06 21:01:42,no_subtitle
-/v/Xe4JqG,2,SAVR-663,2025-07-06 21:01:29,2025-07-06 21:01:29,no_subtitle
-/v/Eb6Awx,2,MKMP-649,2025-07-06 21:01:12,2025-07-06 21:01:12,no_subtitle
-/v/bKwYvP,2,HZGD-310,2025-07-06 21:00:43,2025-07-06 21:00:43,no_subtitle
-/v/3nrZDb,2,REAL-922,2025-07-06 20:59:55,2025-07-06 20:59:55,no_subtitle
-/v/e8OnRd,2,ALDN-480,2025-07-06 20:59:48,2025-07-06 20:59:48,no_subtitle
-/v/e8OAkd,2,BAB-163,2025-07-06 20:59:42,2025-07-06 20:59:42,no_subtitle
-/v/r3Y4Nv,1,PPPE-353,2025-07-06 20:57:13,2025-07-06 20:57:13,subtitle
-/v/5nXb5D,1,PPPE-350,2025-07-06 20:57:06,2025-07-06 20:57:06,subtitle
-/v/bKwOVv,1,PPPE-348,2025-07-06 20:57:00,2025-07-06 20:57:00,subtitle
-/v/Xe4V05,1,PPPE-346,2025-07-06 20:56:53,2025-07-06 20:56:53,subtitle
-/v/QNWrq4,1,PPPE-345,2025-07-06 20:56:47,2025-07-06 20:56:47,subtitle
-/v/mOpM9Z,1,PFAS-033,2025-07-06 20:56:41,2025-07-06 20:56:41,subtitle
-/v/5nXRkB,1,NTRD-125,2025-07-06 20:56:34,2025-07-06 20:56:34,subtitle
-/v/wKkxWn,1,NSFS-393,2025-07-06 20:56:28,2025-07-06 20:56:28,subtitle
-/v/5nXaz7,1,NSFS-392,2025-07-06 20:56:21,2025-07-06 20:56:21,subtitle
-/v/QNW4XG,1,NPJS-201,2025-07-06 20:56:15,2025-07-06 20:56:15,subtitle
-/v/AqK8Vw,1,MIDA-216,2025-07-06 20:56:08,2025-07-06 20:56:08,"hacked_subtitle,subtitle"
-/v/Rk26xp,1,JUR-381,2025-07-06 20:56:02,2025-07-06 20:56:02,"hacked_subtitle,subtitle"
-/v/J2nyW,1,HBAD-361,2025-07-06 20:55:55,2025-07-06 20:55:55,"hacked_no_subtitle,subtitle"
-/v/OXwmO,1,HBAD-345,2025-07-06 20:55:49,2025-07-06 20:55:49,"hacked_no_subtitle,subtitle"
-/v/RkJ2R,1,HBAD-342,2025-07-06 20:55:42,2025-07-06 20:55:42,"hacked_no_subtitle,subtitle"
-/v/dEkJe,2,GVG-813,2025-07-05 22:34:36,2025-07-05 22:34:36,"hacked_no_subtitle,no_subtitle"
-/v/K4ybQ,2,GVG-222,2025-07-05 22:34:34,2025-07-05 22:34:34,"hacked_no_subtitle,no_subtitle"
-/v/E931M,2,FOCS-071,2025-07-05 22:34:33,2025-07-05 22:34:33,"hacked_no_subtitle,no_subtitle"
-/v/96eO55,2,FNS-038,2025-07-05 22:34:31,2025-07-05 22:34:31,"hacked_no_subtitle,no_subtitle"
-/v/3nrZMz,1,FNS-045,2025-07-05 22:33:36,2025-07-05 22:33:36,subtitle
-/v/Rk216D,1,ADN-696,2025-07-05 22:33:30,2025-07-05 22:33:30,"hacked_subtitle,subtitle"
-/v/Mbq3m1,1,FNS-046,2025-07-05 22:31:51,2025-07-05 22:31:51,"hacked_no_subtitle,subtitle"
-/v/V4Nx7X,1,CAWD-858,2025-07-05 22:20:10,2025-07-05 22:20:10,subtitle
-/v/z458V5,1,CAWD-856,2025-07-05 22:20:09,2025-07-05 22:20:09,subtitle
-/v/6dqNXE,1,ABF-241,2025-07-05 22:20:07,2025-07-05 22:20:07,"hacked_subtitle,subtitle"
-/v/YwrB2p,1,DLDSS-403,2025-07-05 22:20:06,2025-07-05 22:20:06,"hacked_no_subtitle,subtitle"
-/v/AqKaz0,1,FNS-039,2025-07-05 22:20:04,2025-07-05 22:20:04,subtitle
-/v/pkq639,1,FNS-048,2025-07-05 22:20:03,2025-07-05 22:20:03,subtitle
-/v/ve06Dp,1,FNS-052,2025-07-05 22:20:01,2025-07-05 22:20:01,subtitle
-/v/82ErvV,1,LUCY-012,2025-07-05 22:20:00,2025-07-05 22:20:00,subtitle
-/v/veZQ5p,1,LUCY-011,2025-07-05 22:19:58,2025-07-05 22:19:58,subtitle
-/v/YwqNB8,1,LUCY-010,2025-07-05 22:19:57,2025-07-05 22:19:57,subtitle
-/v/NQ9Mgx,1,LUCY-007,2025-07-05 22:19:55,2025-07-05 22:19:55,subtitle
-/v/wKY2V2,1,LUCY-006,2025-07-05 22:19:54,2025-07-05 22:19:54,subtitle
-/v/96We6R,1,LUCY-004,2025-07-05 22:19:52,2025-07-05 22:19:52,subtitle
-/v/WwVepg,1,JUTA-172,2025-07-05 22:19:51,2025-07-05 22:19:51,subtitle
-/v/GZ4BNg,1,JUTA-171,2025-07-05 22:19:49,2025-07-05 22:19:49,subtitle
-/v/bKwdO0,1,JRZE-248,2025-07-05 22:19:48,2025-07-05 22:19:48,subtitle
-/v/Xe4vVb,1,JRZE-247,2025-07-05 22:19:46,2025-07-05 22:19:46,subtitle
-/v/82qYB3,1,ADN-689,2025-07-05 22:19:43,2025-07-05 22:19:43,"hacked_subtitle,subtitle"
-/v/merpZ,1,GVG-270,2025-07-05 22:19:42,2025-07-05 22:19:42,"hacked_no_subtitle,subtitle"
-/v/GZ4BWb,2,MIUM-1240,2025-07-05 22:11:50,2025-07-05 22:11:50,no_subtitle
-/v/7yqPVB,2,SAME-190,2025-07-05 22:11:48,2025-07-05 22:11:48,"hacked_subtitle,no_subtitle"
-/v/96q49R,2,EBWH-235,2025-07-05 22:11:47,2025-07-05 22:11:47,"hacked_no_subtitle,no_subtitle"
-/v/WwVVAg,2,EBWH-233,2025-07-05 22:11:45,2025-07-05 22:11:45,"hacked_no_subtitle,no_subtitle"
-/v/wdeOb,2,EBOD-853,2025-07-05 22:11:44,2025-07-05 22:11:44,"hacked_no_subtitle,no_subtitle"
-/v/yxr1Br,2,DPMI-091,2025-07-05 22:11:42,2025-07-05 22:11:42,"hacked_no_subtitle,no_subtitle"
-/v/d4B8OM,2,DPMI-082,2025-07-05 22:11:41,2025-07-05 22:11:41,"hacked_no_subtitle,no_subtitle"
-/v/E4Mp0,2,DGL-064,2025-07-05 22:11:40,2025-07-05 22:11:40,"hacked_no_subtitle,no_subtitle"
-/v/96qZMX,2,IPZZ-611,2025-07-05 22:11:38,2025-07-05 22:11:38,no_subtitle
-/v/Mbqa81,2,MIUM-1244,2025-07-05 22:11:32,2025-07-05 22:11:32,no_subtitle
-/v/qAJBY9,2,RKI-715,2025-07-05 22:11:28,2025-07-05 22:11:28,no_subtitle
-/v/5nXPp9,2,IPZZ-596,2025-07-05 22:11:25,2025-07-05 22:11:25,no_subtitle
-/v/2mqx5P,2,DASS-695,2025-07-05 22:11:23,2025-07-05 22:11:23,no_subtitle
-/v/xAgmGn,2,DASS-682,2025-07-05 22:11:22,2025-07-05 22:11:22,no_subtitle
-/v/1A437A,2,SONE-786,2025-07-05 22:11:20,2025-07-05 22:11:20,no_subtitle
-/v/gyq5vq,2,SVVRT-065,2025-07-05 22:11:17,2025-07-05 22:11:17,no_subtitle
-/v/KkKYrQ,2,START-322,2025-07-05 22:11:16,2025-07-05 22:11:16,no_subtitle
-/v/P92kJN,2,START-355,2025-07-05 22:11:15,2025-07-05 22:11:15,no_subtitle
-/v/7yq7YR,2,START-356,2025-07-05 22:11:13,2025-07-05 22:11:13,no_subtitle
-/v/Eb67nM,2,SDJS-312,2025-07-05 22:11:12,2025-07-05 22:11:12,no_subtitle
-/v/xAg2OV,2,START-372,2025-07-05 22:11:10,2025-07-05 22:11:10,no_subtitle
-/v/a8yvVO,2,SDDE-754,2025-07-05 22:11:09,2025-07-05 22:11:09,no_subtitle
-/v/Ywrd3K,2,SDNM-518,2025-07-05 22:11:07,2025-07-05 22:11:07,no_subtitle
-/v/ZNdB3X,2,MOGI-139,2025-07-05 22:11:06,2025-07-05 22:11:06,no_subtitle
-/v/ZNdgbq,2,START-358,2025-07-05 22:11:04,2025-07-05 22:11:04,no_subtitle
-/v/pkqy0q,2,START-354,2025-07-05 22:11:03,2025-07-05 22:11:03,no_subtitle
-/v/MbqkR4,2,START-352,2025-07-05 22:11:01,2025-07-05 22:11:01,no_subtitle
-/v/kKyGxe,2,START-349,2025-07-05 22:11:00,2025-07-05 22:11:00,no_subtitle
-/v/82q1vW,2,START-331,2025-07-05 22:10:58,2025-07-05 22:10:58,no_subtitle
-/v/Xe4xM4,2,ABF-245,2025-07-05 22:10:55,2025-07-05 22:10:55,no_subtitle
-/v/YwrBOe,2,SONE-803,2025-07-05 22:10:54,2025-07-05 22:10:54,no_subtitle
-/v/qAJYk9,2,DASS-704,2025-07-05 22:10:51,2025-07-05 22:10:51,no_subtitle
-/v/V4Nx5A,2,IPZZ-383,2025-07-05 22:10:45,2025-07-05 22:10:45,no_subtitle
-/v/ve0kgW,2,SONE-780,2025-07-05 22:10:44,2025-07-05 22:10:44,no_subtitle
-/v/MbqM14,2,SONE-796,2025-07-05 22:10:34,2025-07-05 22:10:34,no_subtitle
-/v/Mbqd4P,2,JUR-361,2025-07-05 22:10:29,2025-07-05 22:10:29,no_subtitle
-/v/0edA6b,2,JUR-334,2025-07-05 22:10:28,2025-07-05 22:10:28,no_subtitle
-/v/AqKpkP,2,JUR-331,2025-07-05 22:10:26,2025-07-05 22:10:26,no_subtitle
-/v/ve0xJ8,2,MADV-592,2025-07-05 22:10:25,2025-07-05 22:10:25,no_subtitle
-/v/yx4Reb,2,IPZZ-600,2025-07-05 22:10:22,2025-07-05 22:10:22,no_subtitle
-/v/DRVGB2,2,DASS-657,2025-07-05 22:10:21,2025-07-05 22:10:21,no_subtitle
-/v/ZNdwOq,2,SONE-802,2025-07-05 22:10:19,2025-07-05 22:10:19,no_subtitle
-/v/pkqdnq,2,SONE-800,2025-07-05 22:10:18,2025-07-05 22:10:18,no_subtitle
-/v/Mbq1O1,2,GVH-755,2025-07-05 22:10:12,2025-07-05 22:10:12,no_subtitle
-/v/e8OM5M,1,FNS-074,2025-07-05 22:09:20,2025-07-05 22:09:20,subtitle
-/v/Xe4DOP,2,MDON-077,2025-07-04 20:01:55,2025-07-04 20:01:55,no_subtitle
-/v/QNW4eG,2,SQTE-617,2025-07-04 20:01:54,2025-07-04 20:01:54,no_subtitle
-/v/ve0yK9,2,SUJI-279,2025-07-04 20:01:52,2025-07-04 20:01:52,no_subtitle
-/v/Mbqnxv,2,MAAN-1077,2025-07-04 20:01:51,2025-07-04 20:01:51,no_subtitle
-/v/e8OnPp,2,SAME-187,2025-07-04 20:01:49,2025-07-04 20:01:49,"hacked_subtitle,no_subtitle"
-/v/DRVWDM,2,BLK-653,2025-07-04 20:01:48,2025-07-04 20:01:48,"hacked_no_subtitle,no_subtitle"
-/v/MbqP2Q,2,MIUM-1223,2025-07-04 20:01:46,2025-07-04 20:01:46,no_subtitle
-/v/ZNd5n6,2,LUXU-1843,2025-07-04 20:01:45,2025-07-04 20:01:45,no_subtitle
-/v/V4Nk0n,2,DCV-280,2025-07-04 20:01:43,2025-07-04 20:01:43,no_subtitle
-/v/bKwbNg,2,ABF-243,2025-07-04 20:01:42,2025-07-04 20:01:42,no_subtitle
-/v/WwVepR,1,MIDA-223,2025-07-04 20:00:52,2025-07-04 20:00:52,subtitle
-/v/Mbq17R,1,MIDA-222,2025-07-04 20:00:51,2025-07-04 20:00:51,subtitle
-/v/P92Ov9,1,MIDA-221,2025-07-04 20:00:49,2025-07-04 20:00:49,subtitle
-/v/kKy7Dm,1,MIDA-217,2025-07-04 20:00:47,2025-07-04 20:00:47,subtitle
-/v/ZNdORJ,1,MIDA-215,2025-07-04 20:00:44,2025-07-04 20:00:44,subtitle
-/v/Rk218z,1,MIDA-212,2025-07-04 20:00:42,2025-07-04 20:00:42,subtitle
-/v/Mbq17v,1,ADN-714,2025-07-04 20:00:41,2025-07-04 20:00:41,subtitle
-/v/xaz9B,1,DASD-926,2025-07-04 20:00:39,2025-07-04 20:00:39,"hacked_no_subtitle,subtitle"
-/v/e8OnDN,1,CAWD-845,2025-07-04 20:00:25,2025-07-04 20:00:25,"hacked_subtitle,subtitle"
-/v/KkKDy6,2,JAC-220,2025-07-03 20:01:30,2025-07-03 20:01:30,no_subtitle
-/v/96q556,2,BDST-066,2025-07-03 20:01:28,2025-07-03 20:01:28,no_subtitle
-/v/D22yV2,2,BACJ-022,2025-07-03 20:01:25,2025-07-03 20:01:25,"hacked_no_subtitle,no_subtitle"
-/v/1QWOJ,2,ATID-482,2025-07-03 20:01:24,2025-07-03 20:01:24,"hacked_no_subtitle,no_subtitle"
-/v/Nrgrr,2,APAK-227,2025-07-03 20:01:22,2025-07-03 20:01:22,"hacked_no_subtitle,no_subtitle"
-/v/V4NDxq,2,START-368,2025-07-03 20:01:21,2025-07-03 20:01:21,no_subtitle
-/v/P92Dw9,2,START-353,2025-07-03 20:01:19,2025-07-03 20:01:19,no_subtitle
-/v/xAgb18,2,DDOB-140,2025-07-03 20:01:18,2025-07-03 20:01:18,no_subtitle
-/v/0edmE3,2,LUXU-1842,2025-07-03 20:01:16,2025-07-03 20:01:16,no_subtitle
-/v/5nXbY6,1,ALDN-478,2025-07-03 20:00:48,2025-07-03 20:00:48,subtitle
-/v/bKwOkg,1,ALDN-477,2025-07-03 20:00:47,2025-07-03 20:00:47,subtitle
-/v/Xe4V34,1,ALDN-476,2025-07-03 20:00:46,2025-07-03 20:00:46,subtitle
-/v/mOJnDY,1,ADN-703,2025-07-03 20:00:44,2025-07-03 20:00:44,subtitle
-/v/96qZnX,1,ADN-683,2025-07-03 20:00:40,2025-07-03 20:00:40,subtitle
-/v/WwVe7q,1,ADN-667,2025-07-03 20:00:38,2025-07-03 20:00:38,subtitle
-/v/762Od,1,ATID-284,2025-07-03 20:00:35,2025-07-03 20:00:35,"hacked_no_subtitle,subtitle"
-/v/mezran,1,ALDN-136,2025-07-03 20:00:34,2025-07-03 20:00:34,"hacked_no_subtitle,subtitle"
-/v/0ed123,1,MIDA-220,2025-07-03 20:00:28,2025-07-03 20:00:28,"hacked_subtitle,subtitle"
-/v/mOJnDM,1,MIDA-213,2025-07-03 20:00:22,2025-07-03 20:00:22,"hacked_subtitle,subtitle"
-/v/r3Yrnr,2,NMSL-009,2025-07-02 20:01:44,2025-07-02 20:01:44,no_subtitle
-/v/82qg0K,2,GANA-3223,2025-07-02 20:01:42,2025-07-02 20:01:42,no_subtitle
-/v/deg32Q,2,KIRM-055,2025-07-02 20:01:41,2025-07-02 20:01:41,no_subtitle
-/v/YwrO48,2,SMOK-017,2025-07-02 20:01:39,2025-07-02 20:01:39,no_subtitle
-/v/z45877,2,SORA-602,2025-07-02 20:01:38,2025-07-02 20:01:38,no_subtitle
-/v/96q2kE,2,MIUM-1217,2025-07-02 20:01:37,2025-07-02 20:01:37,no_subtitle
-/v/g0w8q,2,ABP-438,2025-07-02 20:01:35,2025-07-02 20:01:35,"hacked_no_subtitle,no_subtitle"
-/v/yr2v0,2,ABP-421,2025-07-02 20:01:34,2025-07-02 20:01:34,"hacked_no_subtitle,no_subtitle"
-/v/6dqORK,2,OLM-208,2025-07-02 20:01:32,2025-07-02 20:01:32,no_subtitle
-/v/96qr2w,2,TDAN-009,2025-07-02 20:01:31,2025-07-02 20:01:31,no_subtitle
-/v/e8OYnp,1,VEC-710,2025-07-02 20:00:59,2025-07-02 20:00:59,subtitle
-/v/qAJGYP,1,VEC-709,2025-07-02 20:00:58,2025-07-02 20:00:58,subtitle
-/v/2mq8xq,1,VEC-708,2025-07-02 20:00:56,2025-07-02 20:00:56,subtitle
-/v/6dqwxD,1,ROE-367,2025-07-02 20:00:55,2025-07-02 20:00:55,subtitle
-/v/Eb6mZd,1,ROE-362,2025-07-02 20:00:53,2025-07-02 20:00:53,subtitle
-/v/xAgPDg,1,ROE-360,2025-07-02 20:00:52,2025-07-02 20:00:52,subtitle
-/v/a8ym4q,1,ROE-359,2025-07-02 20:00:50,2025-07-02 20:00:50,subtitle
-/v/4DdnVG,1,ROE-356,2025-07-02 20:00:49,2025-07-02 20:00:49,subtitle
-/v/DRVAYK,1,ROE-354,2025-07-02 20:00:47,2025-07-02 20:00:47,subtitle
-/v/MbYJ8Q,1,REAL-916,2025-07-02 20:00:46,2025-07-02 20:00:46,subtitle
-/v/zKQgXJ,1,ALDN-124,2025-07-02 20:00:44,2025-07-02 20:00:44,"hacked_no_subtitle,subtitle"
-/v/Mm6DzQ,1,ALDN-069,2025-07-02 20:00:43,2025-07-02 20:00:43,"hacked_no_subtitle,subtitle"
-/v/OXXE4y,1,ADN-610,2025-07-02 20:00:41,2025-07-02 20:00:41,"hacked_no_subtitle,subtitle"
-/v/bAVD3g,1,ADN-539,2025-07-02 20:00:40,2025-07-02 20:00:40,"hacked_no_subtitle,subtitle"
-/v/67x8D,1,ADN-361,2025-07-02 20:00:38,2025-07-02 20:00:38,"hacked_no_subtitle,subtitle"
-/v/neYG6a,1,ABW-318,2025-07-02 20:00:37,2025-07-02 20:00:37,"hacked_no_subtitle,subtitle"
-/v/V7v7n,1,ABP-968,2025-07-02 20:00:35,2025-07-02 20:00:35,"hacked_no_subtitle,subtitle"
-/v/YwrO3B,1,ATID-637,2025-07-02 20:00:34,2025-07-02 20:00:34,"hacked_subtitle,subtitle"
-/v/0edZvq,2,MAAN-1086,2025-07-01 21:01:56,2025-07-01 21:01:56,no_subtitle
-/v/Eb6pGd,2,NMSL-007,2025-07-01 21:01:54,2025-07-01 21:01:54,no_subtitle
-/v/YwrgRD,2,JAC-219,2025-07-01 21:01:52,2025-07-01 21:01:52,no_subtitle
-/v/kKYw8P,2,VDD-193,2025-07-01 21:01:51,2025-07-01 21:01:51,"hacked_no_subtitle,no_subtitle"
-/v/3nrOk0,2,SAN-362,2025-07-01 21:01:48,2025-07-01 21:01:48,no_subtitle
-/v/mOJn8D,2,VDD-194,2025-07-01 21:01:47,2025-07-01 21:01:47,no_subtitle
-/v/OXW6Vz,2,DVMM-263,2025-07-01 21:01:45,2025-07-01 21:01:45,no_subtitle
-/v/QN0EBK,1,KSBJ-377,2025-07-01 21:01:11,2025-07-01 21:01:11,subtitle
-/v/BzKz0O,1,KSBJ-372,2025-07-01 21:01:10,2025-07-01 21:01:10,subtitle
-/v/yx0x3A,1,KSBJ-370,2025-07-01 21:01:08,2025-07-01 21:01:08,subtitle
-/v/Kk2A2v,1,JUNY-157,2025-07-01 21:01:06,2025-07-01 21:01:06,subtitle
-/v/AqEO3w,1,HUNTC-362,2025-07-01 21:01:05,2025-07-01 21:01:05,subtitle
-/v/mOpGZM,1,HUNTC-352,2025-07-01 21:01:03,2025-07-01 21:01:03,subtitle
-/v/96e506,1,HUNTC-331,2025-07-01 21:01:02,2025-07-01 21:01:02,subtitle
-/v/Eb6Pe2,1,HUNTC-202,2025-07-01 21:01:00,2025-07-01 21:01:00,subtitle
-/v/z45bqJ,1,HMN-714,2025-07-01 21:00:59,2025-07-01 21:00:59,subtitle
-/v/P92Jza,1,HMN-698,2025-07-01 21:00:57,2025-07-01 21:00:57,subtitle
-/v/qOXMN,1,CWPBD-09,2025-07-01 21:00:56,2025-07-01 21:00:56,subtitle
-/v/BzK6rG,1,YUJ-040,2025-07-01 21:00:54,2025-07-01 21:00:54,"hacked_no_subtitle,subtitle"
-/v/GZdpDD,1,WAAA-540,2025-07-01 21:00:52,2025-07-01 21:00:52,"hacked_no_subtitle,subtitle"
-/v/82EvDK,1,WAAA-528,2025-07-01 21:00:50,2025-07-01 21:00:50,"hacked_no_subtitle,subtitle"
-/v/96eKJE,1,WAAA-526,2025-07-01 21:00:49,2025-07-01 21:00:49,"hacked_no_subtitle,subtitle"
-/v/Ww3g9g,1,WAAA-524,2025-07-01 21:00:48,2025-07-01 21:00:48,"hacked_no_subtitle,subtitle"
-/v/QMKY7,1,VENX-108,2025-07-01 21:00:46,2025-07-01 21:00:46,"hacked_no_subtitle,subtitle"
-/v/r3YZDk,2,FJIN-085,2025-06-30 21:01:43,2025-06-30 21:01:43,no_subtitle
-/v/BzgnQG,2,MIUM-1239,2025-06-30 21:01:42,2025-06-30 21:01:42,no_subtitle
-/v/nKz8Re,2,ARSO-2519,2025-06-30 21:01:40,2025-06-30 21:01:40,no_subtitle
-/v/V4NxKq,2,MRSS-169,2025-06-30 21:01:39,2025-06-30 21:01:39,no_subtitle
-/v/QNWy6J,2,HALE-064,2025-06-30 21:01:37,2025-06-30 21:01:37,no_subtitle
-/v/qAOra,2,VDD-094,2025-06-30 21:01:36,2025-06-30 21:01:36,"hacked_no_subtitle,no_subtitle"
-/v/Xe4V55,2,START-336,2025-06-30 21:01:34,2025-06-30 21:01:34,"hacked_no_subtitle,no_subtitle"
-/v/NQP6Eg,2,START-327,2025-06-30 21:01:33,2025-06-30 21:01:33,"hacked_no_subtitle,no_subtitle"
-/v/GZ4nEz,2,START-299,2025-06-30 21:01:31,2025-06-30 21:01:31,"hacked_no_subtitle,no_subtitle"
-/v/MmVaPX,2,SONE-028,2025-06-30 21:01:30,2025-06-30 21:01:30,"hacked_no_subtitle,no_subtitle"
-/v/GZ4BG7,2,XVSR-823,2025-06-30 21:01:28,2025-06-30 21:01:28,no_subtitle
-/v/NQPOrN,2,XVSR-822,2025-06-30 21:01:27,2025-06-30 21:01:27,no_subtitle
-/v/Bzg9Ad,2,FKOU-002,2025-06-30 21:01:25,2025-06-30 21:01:25,no_subtitle
-/v/wKkxK2,2,MAAN-1079,2025-06-30 21:01:24,2025-06-30 21:01:24,no_subtitle
-/v/yx4Y1a,2,MIUM-1210,2025-06-30 21:01:23,2025-06-30 21:01:23,no_subtitle
-/v/kKyaxJ,2,HNVR-147,2025-06-30 21:01:15,2025-06-30 21:01:15,no_subtitle
-/v/Xe47kb,1,JUR-324,2025-06-30 21:00:37,2025-06-30 21:00:37,"hacked_subtitle,subtitle"
-/v/QNW7xM,1,JUR-316,2025-06-30 21:00:36,2025-06-30 21:00:36,"hacked_subtitle,subtitle"
-/v/4zR6,1,NTR-037,2025-06-30 21:00:22,2025-06-30 21:00:22,"hacked_subtitle,subtitle"
-/v/wKpW9e,1,YUJ-039,2025-06-30 21:00:20,2025-06-30 21:00:20,"hacked_subtitle,subtitle"
-/v/QNW47n,2,CLUB-877,2025-06-29 22:31:31,2025-06-29 22:31:31,no_subtitle
-/v/OXW678,2,CAWD-854,2025-06-29 22:31:30,2025-06-29 22:31:30,no_subtitle
-/v/ZNdO3V,2,MIMK-231,2025-06-29 22:31:27,2025-06-29 22:31:27,no_subtitle
-/v/P92O79,2,SAME-191,2025-06-29 22:31:25,2025-06-29 22:31:25,no_subtitle
-/v/J06gPA,2,CAWD-857,2025-06-29 22:31:21,2025-06-29 22:31:21,no_subtitle
-/v/AqK8VO,2,ADN-705,2025-06-29 22:31:19,2025-06-29 22:31:19,no_subtitle
-/v/96qZQ6,2,MIDA-133,2025-06-29 22:31:18,2025-06-29 22:31:18,no_subtitle
-/v/xAgk4E,2,KIT-011,2025-06-29 22:31:17,2025-06-29 22:31:17,no_subtitle
-/v/yx46Qr,2,LUXU-1841,2025-06-29 22:31:15,2025-06-29 22:31:15,no_subtitle
-/v/GZ4b7m,2,SDHS-060,2025-06-29 22:31:14,2025-06-29 22:31:14,no_subtitle
-/v/82qYza,2,MIMK-230,2025-06-29 22:31:11,2025-06-29 22:31:11,no_subtitle
-/v/mOJRzd,2,HAWA-358,2025-06-29 22:31:09,2025-06-29 22:31:09,no_subtitle
-/v/KkK0JO,2,HODV-2198,2025-06-29 22:31:03,2025-06-29 22:31:03,no_subtitle
-/v/3nrDpa,2,MIAB-510,2025-06-29 22:31:02,2025-06-29 22:31:02,no_subtitle
-/v/6dqPkE,2,MIAB-507,2025-06-29 22:31:00,2025-06-29 22:31:00,no_subtitle
-/v/kKyDVP,1,JUR-401,2025-06-29 17:52:03,2025-06-29 17:52:03,subtitle
-/v/AqKVxM,1,JUR-385,2025-06-29 17:52:01,2025-06-29 17:52:01,subtitle
-/v/mOJDaR,1,JUR-382,2025-06-29 17:52:00,2025-06-29 17:52:00,subtitle
-/v/pxAVq,1,n0996東熱に遥香見参！,2025-06-29 17:51:57,2025-06-29 17:51:57,subtitle
-/v/NQZJ6B,1,FUGA-061,2025-06-29 17:51:54,2025-06-29 17:51:54,subtitle
-/v/1AyQ4A,1,FUGA-060,2025-06-29 17:51:53,2025-06-29 17:51:53,"hacked_no_subtitle,subtitle"
-/v/Eb6GJJ,1,FERA-198,2025-06-29 17:51:51,2025-06-29 17:51:51,subtitle
-/v/deRmQv,1,FERA-197,2025-06-29 17:51:50,2025-06-29 17:51:50,subtitle
-/v/yx0KVg,1,DLDSS-408,2025-06-29 17:51:48,2025-06-29 17:51:48,"hacked_no_subtitle,subtitle"
-/v/4DdxXE,1,DASS-698,2025-06-29 17:51:45,2025-06-29 17:51:45,subtitle
-/v/DRVnxJ,1,DASS-684,2025-06-29 17:51:44,2025-06-29 17:51:44,subtitle
-/v/5nXbkD,1,START-333,2025-06-29 17:51:42,2025-06-29 17:51:42,"hacked_no_subtitle,subtitle"
-/v/9wP7E,1,STARS-345,2025-06-29 17:51:40,2025-06-29 17:51:40,"hacked_no_subtitle,subtitle"
-/v/YNVG6,1,STARS-342,2025-06-29 17:51:39,2025-06-29 17:51:39,"hacked_no_subtitle,subtitle"
-/v/WQqKq,2,OFJE-186,2025-06-29 17:40:29,2025-06-29 17:40:29,no_subtitle
-/v/nn0W4,2,SSIS-163,2025-06-29 17:40:27,2025-06-29 17:40:27,no_subtitle
-/v/b26Ae,2,SSIS-165,2025-06-29 17:40:26,2025-06-29 17:40:26,no_subtitle
-/v/XO6WP,2,SSIS-164,2025-06-29 17:40:24,2025-06-29 17:40:24,no_subtitle
-/v/kNXY4,2,SIVR-171,2025-06-29 17:40:23,2025-06-29 17:40:23,no_subtitle
-/v/JK5Ez,2,OFJE-347,2025-06-29 17:40:21,2025-06-29 17:40:21,no_subtitle
-/v/KOvE0,2,OAE-214,2025-06-29 17:40:20,2025-06-29 17:40:20,no_subtitle
-/v/d6Mme,2,OFJE-3511,2025-06-29 17:40:18,2025-06-29 17:40:18,no_subtitle
-/v/V37AQ,2,SIVR-191,2025-06-29 17:40:17,2025-06-29 17:40:17,no_subtitle
-/v/QGmmp,2,SIVR-204,2025-06-29 17:40:15,2025-06-29 17:40:15,no_subtitle
-/v/OndQz,2,SIVR-212,2025-06-29 17:40:14,2025-06-29 17:40:14,no_subtitle
-/v/B8Kk49,2,SIVR-226,2025-06-29 17:40:13,2025-06-29 17:40:13,no_subtitle
-/v/p3Onew,2,SIVR-231,2025-06-29 17:40:11,2025-06-29 17:40:11,no_subtitle
-/v/9Dpywg,2,RBB-247,2025-06-29 17:40:10,2025-06-29 17:40:10,no_subtitle
-/v/rmzmJr,2,OAE-228,2025-06-29 17:40:08,2025-06-29 17:40:08,no_subtitle
-/v/PQwdka,2,SIVR-251,2025-06-29 17:40:07,2025-06-29 17:40:07,no_subtitle
-/v/8VaNX5,2,SIVR-247,2025-06-29 17:40:05,2025-06-29 17:40:05,no_subtitle
-/v/2ay9nm,2,SIVR-270,2025-06-29 17:40:04,2025-06-29 17:40:04,no_subtitle
-/v/8V8G8W,2,SIVR-277,2025-06-29 17:40:02,2025-06-29 17:40:02,no_subtitle
-/v/K43w5v,2,SIVR-293,2025-06-29 17:40:01,2025-06-29 17:40:01,"hacked_no_subtitle,no_subtitle"
-/v/AzDDVO,2,OFJE-431,2025-06-29 17:39:59,2025-06-29 17:39:59,no_subtitle
-/v/Vw5ebW,2,SIVR-302,2025-06-29 17:39:58,2025-06-29 17:39:58,"hacked_no_subtitle,no_subtitle"
-/v/Yn6aXK,2,OAE-249,2025-06-29 17:39:56,2025-06-29 17:39:56,no_subtitle
-/v/wKnOXe,2,SIVR-326,2025-06-29 17:39:55,2025-06-29 17:39:55,no_subtitle
-/v/7yyPJd,2,SIVR-361,2025-06-29 17:39:53,2025-06-29 17:39:53,no_subtitle
-/v/bKKbJv,2,OFJE-459,2025-06-29 17:39:52,2025-06-29 17:39:52,no_subtitle
-/v/QNNwgG,2,OFJE-465,2025-06-29 17:39:50,2025-06-29 17:39:50,no_subtitle
-/v/Mbba21,2,OFJE-470,2025-06-29 17:39:49,2025-06-29 17:39:49,no_subtitle
-/v/kKKw24,2,OAE-262,2025-06-29 17:39:47,2025-06-29 17:39:47,no_subtitle
-/v/4MdG,1,SSNI-190,2025-06-29 17:39:34,2025-06-29 17:39:34,subtitle
-/v/Bz1YG,1,SSNI-216,2025-06-29 17:39:32,2025-06-29 17:39:32,subtitle
-/v/V4GbA,1,SSNI-240,2025-06-29 17:39:31,2025-06-29 17:39:31,"hacked_no_subtitle,subtitle"
-/v/V4MZz,1,SSNI-266,2025-06-29 17:39:29,2025-06-29 17:39:29,subtitle
-/v/WwG3Q,1,SSNI-288,2025-06-29 17:39:28,2025-06-29 17:39:28,subtitle
-/v/0eGn3,1,SSNI-309,2025-06-29 17:39:26,2025-06-29 17:39:26,subtitle
-/v/EEgAd,1,SSIS-161,2025-06-29 17:39:25,2025-06-29 17:39:25,subtitle
-/v/x6qxg,1,SSIS-129,2025-06-29 17:39:23,2025-06-29 17:39:23,"hacked_subtitle,subtitle"
-/v/POZPJ,1,SSIS-162,2025-06-29 17:39:22,2025-06-29 17:39:22,subtitle
-/v/abZJp,1,SSIS-158,2025-06-29 17:39:20,2025-06-29 17:39:20,"hacked_subtitle,subtitle"
-/v/JpzGd,1,SSIS-194,2025-06-29 17:39:19,2025-06-29 17:39:19,"hacked_subtitle,subtitle"
-/v/1zNJw,1,SSIS-222,2025-06-29 17:39:17,2025-06-29 17:39:17,"hacked_subtitle,subtitle"
-/v/EyeR4,1,SSIS-252,2025-06-29 17:39:16,2025-06-29 17:39:16,"hacked_subtitle,no_subtitle"
-/v/mBm4v,1,SSIS-280,2025-06-29 17:39:14,2025-06-29 17:39:14,"hacked_subtitle,subtitle"
-/v/dXWVe,1,SSIS-308,2025-06-29 17:39:13,2025-06-29 17:39:13,"hacked_subtitle,subtitle"
-/v/b6ZDv,1,SSIS-334,2025-06-29 17:39:11,2025-06-29 17:39:11,"hacked_subtitle,subtitle"
-/v/rJ23R,1,SSIS-3611,2025-06-29 17:39:10,2025-06-29 17:39:10,"hacked_subtitle,subtitle"
-/v/RwRw4,1,SSIS-387,2025-06-29 17:39:08,2025-06-29 17:39:08,"hacked_subtitle,subtitle"
-/v/EY5kJ,1,SSIS-413,2025-06-29 17:39:07,2025-06-29 17:39:07,"hacked_subtitle,subtitle"
-/v/OP77B,1,SSIS-4404,2025-06-29 17:39:06,2025-06-29 17:39:06,"hacked_subtitle,no_subtitle"
-/v/0Rvnp3,1,SSIS-468,2025-06-29 17:39:04,2025-06-29 17:39:04,"hacked_subtitle,subtitle"
-/v/1BAd4d,1,SSIS-499,2025-06-29 17:39:03,2025-06-29 17:39:03,"hacked_subtitle,subtitle"
-/v/g0O1Yq,1,SSIS-531,2025-06-29 17:39:01,2025-06-29 17:39:01,"hacked_subtitle,subtitle"
-/v/W1KVxK,1,SSIS-560,2025-06-29 17:39:00,2025-06-29 17:39:00,"hacked_subtitle,subtitle"
-/v/W14M5q,1,SSIS-586,2025-06-29 17:38:58,2025-06-29 17:38:58,"hacked_subtitle,subtitle"
-/v/PQ8O7v,1,SSIS-595,2025-06-29 17:38:57,2025-06-29 17:38:57,"hacked_subtitle,subtitle"
-/v/MmEXER,1,SSIS-607,2025-06-29 17:38:55,2025-06-29 17:38:55,"hacked_no_subtitle,subtitle"
-/v/eKb2wp,1,SSIS-685,2025-06-29 17:38:54,2025-06-29 17:38:54,"hacked_subtitle,subtitle"
-/v/YnJMe6,1,SSIS-721,2025-06-29 17:38:52,2025-06-29 17:38:52,"hacked_subtitle,no_subtitle"
-/v/B8wE34,1,SSIS-762,2025-06-29 17:38:51,2025-06-29 17:38:51,"hacked_subtitle,subtitle"
-/v/MmvbqX,1,SSIS-839,2025-06-29 17:38:49,2025-06-29 17:38:49,"hacked_subtitle,subtitle"
-/v/g08yOm,1,SSIS-801,2025-06-29 17:38:48,2025-06-29 17:38:48,"hacked_subtitle,subtitle"
-/v/g0JB2Z,1,SSIS-875,2025-06-29 17:38:46,2025-06-29 17:38:46,"hacked_subtitle,subtitle"
-/v/Yn167x,1,SSIS-913,2025-06-29 17:38:45,2025-06-29 17:38:45,"hacked_subtitle,subtitle"
-/v/J2QAg3,1,SSIS-951,2025-06-29 17:38:43,2025-06-29 17:38:43,"hacked_subtitle,subtitle"
-/v/1BnXvw,1,SSIS-984,2025-06-29 17:38:42,2025-06-29 17:38:42,"hacked_subtitle,subtitle"
-/v/qD5Ew6,1,SONE-027,2025-06-29 17:38:40,2025-06-29 17:38:40,"hacked_subtitle,subtitle"
-/v/K4zV5m,1,SONE-071,2025-06-29 17:38:39,2025-06-29 17:38:39,"hacked_subtitle,subtitle"
-/v/bKAA06,1,SONE-118,2025-06-29 17:38:37,2025-06-29 17:38:37,"hacked_subtitle,subtitle"
-/v/Ww1yPp,1,SONE-153,2025-06-29 17:38:36,2025-06-29 17:38:36,"hacked_subtitle,subtitle"
-/v/GZMEbD,1,SONE-2001,2025-06-29 17:38:34,2025-06-29 17:38:34,"hacked_subtitle,subtitle"
-/v/4D5B1v,1,SONE-228,2025-06-29 17:38:33,2025-06-29 17:38:33,"hacked_subtitle,subtitle"
-/v/4D5XME,1,SONE-266,2025-06-29 17:38:32,2025-06-29 17:38:32,"hacked_subtitle,subtitle"
-/v/GZZdZ7,1,SONE-311,2025-06-29 17:38:30,2025-06-29 17:38:30,"hacked_subtitle,subtitle"
-/v/QNN9e4,1,SONE-360,2025-06-29 17:38:29,2025-06-29 17:38:29,"hacked_subtitle,subtitle"
-/v/QNNmQp,1,SONE-405,2025-06-29 17:38:27,2025-06-29 17:38:27,"hacked_subtitle,subtitle"
-/v/veeE4G,1,SONE-454,2025-06-29 17:38:26,2025-06-29 17:38:26,"hacked_subtitle,subtitle"
-/v/Yww4d6,1,SONE-499,2025-06-29 17:38:24,2025-06-29 17:38:24,"hacked_subtitle,subtitle"
-/v/6dDJKQ,1,SIVR-394,2025-06-29 17:38:23,2025-06-29 17:38:23,subtitle
-/v/KknQbv,1,SONE-642,2025-06-29 17:38:21,2025-06-29 17:38:21,"hacked_subtitle,subtitle"
-/v/z4M7xb,1,SONE-543,2025-06-29 17:38:20,2025-06-29 17:38:20,"hacked_subtitle,subtitle"
-/v/Ebd6k0,1,SONE-561,2025-06-29 17:38:18,2025-06-29 17:38:18,"hacked_subtitle,subtitle"
-/v/BzK0wM,1,SONE-687,2025-06-29 17:38:17,2025-06-29 17:38:17,"hacked_subtitle,subtitle"
-/v/a8BYxX,1,SONE-725,2025-06-29 17:38:15,2025-06-29 17:38:15,"hacked_subtitle,subtitle"
-/v/a8yV0p,1,SONE-763,2025-06-29 17:38:14,2025-06-29 17:38:14,"hacked_subtitle,subtitle"
-/v/4Ddxap,1,SONE-563,2025-06-29 17:38:12,2025-06-29 17:38:12,"hacked_subtitle,subtitle"
-/v/82qPRa,1,SONE-769,2025-06-29 14:30:12,2025-06-29 14:30:12,"hacked_subtitle,subtitle"
-/v/degd5M,1,SONE-741,2025-06-29 14:30:11,2025-06-29 14:30:11,"hacked_subtitle,subtitle"
-/v/yx4kqZ,1,SONE-573,2025-06-29 14:30:09,2025-06-29 14:30:09,"hacked_subtitle,subtitle"
-/v/E2Yav4,1,SONE-008,2025-06-29 14:30:02,2025-06-29 14:30:02,"hacked_subtitle,subtitle"
-/v/0ed1Av,1,START-328,2025-06-29 14:29:59,2025-06-29 14:29:59,"hacked_subtitle,subtitle"
-/v/5nXNx7,1,JUR-3403,2025-06-29 14:29:56,2025-06-29 14:29:56,"hacked_subtitle,subtitle"
-/v/ZNdxb8,1,DASS-651,2025-06-29 14:29:43,2025-06-29 14:29:43,"hacked_subtitle,subtitle"
-/v/pkqe09,1,DASS-650,2025-06-29 14:29:41,2025-06-29 14:29:41,"hacked_subtitle,subtitle"
-/v/yx45qW,1,START-339,2025-06-29 14:29:40,2025-06-29 14:29:40,"hacked_subtitle,subtitle"
+﻿href,phase,video_code,create_date,update_date,hacked_subtitle,hacked_no_subtitle,subtitle,no_subtitle
+/v/Rk2rnn,1,JUR-414,2025-07-12 22:29:03,2025-07-12 22:35:22,2025-07-12 22:35:22,,2025-07-12 22:35:22,2025-07-12 22:35:22
+/v/DRV7DM,2,MFYD-028,2025-07-12 22:32:29,2025-07-12 22:32:29,,,,2025-07-12 22:32:29
+/v/kKy8AN,2,EYAN-203,2025-07-12 22:32:26,2025-07-12 22:32:26,,,,2025-07-12 22:32:26
+/v/kKybem,2,MFYD-021,2025-07-11 20:05:34,2025-07-12 22:32:23,,2025-07-12 22:32:23,,2025-07-12 22:32:23
+/v/4DdE0R,2,MDVR-354,2025-07-12 22:32:20,2025-07-12 22:32:20,,2025-07-12 22:32:20,,2025-07-12 22:32:20
+/v/Xe4d5G,2,NHDTC-078,2025-07-12 22:32:13,2025-07-12 22:32:13,,,,2025-07-12 22:32:13
+/v/YwrB8p,2,MIDA-228,2025-07-12 22:32:05,2025-07-12 22:32:05,,,,2025-07-12 22:32:05
+/v/Mbqp9k,2,MIDA-244,2025-07-12 22:32:02,2025-07-12 22:32:02,,,,2025-07-12 22:32:02
+/v/mOJvM5,2,HMN-720,2025-07-12 22:31:56,2025-07-12 22:31:56,,,,2025-07-12 22:31:56
+/v/Rk2RpD,2,MIDA-248,2025-07-12 22:31:54,2025-07-12 22:31:54,,,,2025-07-12 22:31:54
+/v/mOJWxY,2,MIKR-026,2025-07-12 22:31:48,2025-07-12 22:31:48,,,,2025-07-12 22:31:48
+/v/YwrdDD,2,MFYD-024,2025-07-12 22:31:43,2025-07-12 22:31:43,,,,2025-07-12 22:31:43
+/v/Rk2m0m,2,PPPE-355,2025-07-12 22:31:37,2025-07-12 22:31:37,,,,2025-07-12 22:31:37
+/v/MbqMAv,2,FPRE-185,2025-07-12 22:31:34,2025-07-12 22:31:34,,,,2025-07-12 22:31:34
+/v/ZNdw9m,2,PRED-783,2025-07-12 22:31:31,2025-07-12 22:31:31,,,,2025-07-12 22:31:31
+/v/V4NWRQ,2,VENX-328,2025-07-12 22:31:26,2025-07-12 22:31:26,,,,2025-07-12 22:31:26
+/v/4Dd3J3,2,MFYD-029,2025-07-12 22:31:23,2025-07-12 22:31:23,,,,2025-07-12 22:31:23
+/v/pkqdYZ,2,PRED-782,2025-07-12 22:31:20,2025-07-12 22:31:20,,,,2025-07-12 22:31:20
+/v/82qAg3,2,MIDA-240,2025-07-12 22:31:17,2025-07-12 22:31:17,,,,2025-07-12 22:31:17
+/v/mOJ2Gv,2,MIDA-237,2025-07-12 22:31:14,2025-07-12 22:31:14,,,,2025-07-12 22:31:14
+/v/82q785,2,PPPE-351,2025-07-12 22:31:11,2025-07-12 22:31:11,,,,2025-07-12 22:31:11
+/v/Eb67Dx,2,MIAB-506,2025-07-12 22:31:08,2025-07-12 22:31:08,,,,2025-07-12 22:31:08
+/v/e8OMYN,2,FPRE-186,2025-07-12 22:31:05,2025-07-12 22:31:05,,,,2025-07-12 22:31:05
+/v/MbqpPk,2,PRED-790,2025-07-12 22:30:57,2025-07-12 22:30:57,,,,2025-07-12 22:30:57
+/v/0ed7ZX,2,PRED-786,2025-07-12 22:30:54,2025-07-12 22:30:54,,,,2025-07-12 22:30:54
+/v/MbqMyv,2,PRED-781,2025-07-12 22:30:51,2025-07-12 22:30:51,,,,2025-07-12 22:30:51
+/v/6dqWE7,2,MIAB-501,2025-07-12 16:29:46,2025-07-12 22:30:46,,2025-07-12 22:30:46,,2025-07-12 22:30:46
+/v/qAJ21e,2,MIDA-238,2025-07-12 22:30:38,2025-07-12 22:30:38,,,,2025-07-12 22:30:38
+/v/ZNdwYm,2,FPRE-190,2025-07-12 22:30:33,2025-07-12 22:30:33,,,,2025-07-12 22:30:33
+/v/ZNdObq,2,HUBLK-056,2025-07-12 22:30:20,2025-07-12 22:30:20,,,,2025-07-12 22:30:20
+/v/Rk2vOm,2,MCKT-019,2025-07-12 22:30:17,2025-07-12 22:30:17,,,,2025-07-12 22:30:17
+/v/WwVG58,2,MIAB-500,2025-07-12 22:30:14,2025-07-12 22:30:14,,,,2025-07-12 22:30:14
+/v/AqK7ge,2,PPPE-362,2025-07-12 22:30:11,2025-07-12 22:30:11,,,,2025-07-12 22:30:11
+/v/0edXEa,2,HJMO-685,2025-07-12 22:30:08,2025-07-12 22:30:08,,,,2025-07-12 22:30:08
+/v/96qm2X,2,MIDA-235,2025-07-12 22:30:03,2025-07-12 22:30:03,,,,2025-07-12 22:30:03
+/v/kKyzd0,1,JUR-436,2025-07-12 22:29:09,2025-07-12 22:29:09,,,2025-07-12 22:29:09,2025-07-12 22:29:09
+/v/AqKpGm,1,JUR-430,2025-07-12 22:29:06,2025-07-12 22:29:06,,,2025-07-12 22:29:06,2025-07-12 22:29:06
+/v/ve0kKp,1,JUFE-591,2025-07-12 22:29:00,2025-07-12 22:29:00,,,2025-07-12 22:29:00,2025-07-12 22:29:00
+/v/V4NMMW,1,JRZE-249,2025-07-12 22:28:57,2025-07-12 22:28:57,,,2025-07-12 22:28:57,2025-07-12 22:28:57
+/v/96q27q,1,JRZE-246,2025-07-12 22:28:54,2025-07-12 22:28:54,,,2025-07-12 22:28:54,2025-07-12 22:28:54
+/v/NQPOVG,1,IPZZ-605,2025-07-12 22:28:49,2025-07-12 22:28:49,,,2025-07-12 22:28:49,2025-07-12 22:28:49
+/v/xAgmyQ,1,IPSE-016,2025-07-12 22:28:46,2025-07-12 22:28:46,,,2025-07-12 22:28:46,2025-07-12 22:28:46
+/v/GZ4BvJ,1,IPSE-013,2025-07-12 22:28:43,2025-07-12 22:28:43,,,2025-07-12 22:28:43,2025-07-12 22:28:43
+/v/6dqPVZ,1,DASS-692,2025-07-12 22:28:40,2025-07-12 22:28:40,,,2025-07-12 22:28:40,2025-07-12 22:28:40
+/v/Eb6NY9,1,DASS-690,2025-07-12 22:28:37,2025-07-12 22:28:37,,,2025-07-12 22:28:37,2025-07-12 22:28:37
+/v/d4nW89,1,MIDV-316,2025-07-12 22:28:34,2025-07-12 22:28:34,,2025-07-12 22:28:34,2025-07-12 22:28:34,2025-07-12 22:28:34
+/v/XWxXde,1,MIDV-305,2025-07-12 22:28:31,2025-07-12 22:28:31,2025-07-12 22:28:31,,,2025-07-12 22:28:31
+/v/wq0abe,1,MIDV-290,2025-07-12 22:28:28,2025-07-12 22:28:28,,2025-07-12 22:28:28,2025-07-12 22:28:28,2025-07-12 22:28:28
+/v/yrAaQg,1,MIDV-278,2025-07-12 22:28:25,2025-07-12 22:28:25,2025-07-12 22:28:25,,2025-07-12 22:28:25,2025-07-12 22:28:25
+/v/akKE7q,1,MIDV-267,2025-07-12 22:28:22,2025-07-12 22:28:22,2025-07-12 22:28:22,,2025-07-12 22:28:22,2025-07-12 22:28:22
+/v/wKkgkz,1,MIDA-204,2025-07-12 22:28:19,2025-07-12 22:28:19,,2025-07-12 22:28:19,2025-07-12 22:28:19,2025-07-12 22:28:19
+/v/gyqQqG,1,MIDA-201,2025-07-12 22:28:17,2025-07-12 22:28:17,2025-07-12 22:28:17,,2025-07-12 22:28:17,2025-07-12 22:28:17
+/v/ZNdp6X,1,MIDA-194,2025-07-12 22:28:14,2025-07-12 22:28:14,,2025-07-12 22:28:14,2025-07-12 22:28:14,2025-07-12 22:28:14
+/v/5nXbBa,1,MIAB-502,2025-07-12 22:28:11,2025-07-12 22:28:11,,2025-07-12 22:28:11,2025-07-12 22:28:11,2025-07-12 22:28:11
+/v/0edA3q,2,JUR-443,2025-07-05 22:10:23,2025-07-12 16:29:52,2025-07-12 16:29:52,,,2025-07-12 16:29:52
+/v/a8yv1g,2,MFYD-030,2025-07-12 16:29:28,2025-07-12 16:29:28,,,,2025-07-12 16:29:28
+/v/yx4Q3b,2,FPRE-187,2025-07-12 16:29:22,2025-07-12 16:29:22,,,,2025-07-12 16:29:22
+/v/BzgwO6,2,EBWH-242,2025-07-12 16:29:15,2025-07-12 16:29:15,,,,2025-07-12 16:29:15
+/v/YwrB8B,2,PRED-784,2025-07-12 16:29:09,2025-07-12 16:29:09,,,,2025-07-12 16:29:09
+/v/82qYp3,1,IPZZ-613,2025-07-05 22:11:31,2025-07-12 16:26:01,2025-07-12 16:26:01,,2025-07-12 16:26:01,
+/v/J06YEq,2,MOON-044,2025-07-11 20:06:49,2025-07-11 20:06:49,,,,2025-07-11 20:06:49
+/v/P92AEr,2,HBAD-713,2025-07-11 20:06:31,2025-07-11 20:06:31,,,,2025-07-11 20:06:31
+/v/ve02vk,2,MNGS-007,2025-07-11 20:06:25,2025-07-11 20:06:25,,,,2025-07-11 20:06:25
+/v/WwVZOZ,2,SIRO-5488,2025-07-11 20:06:13,2025-07-11 20:06:13,,,,2025-07-11 20:06:13
+/v/kKy29V,2,MIDA-242,2025-07-11 20:06:06,2025-07-11 20:06:06,,,,2025-07-11 20:06:06
+/v/r3YRvJ,2,HMN-712,2025-07-11 20:06:00,2025-07-11 20:06:00,,,,2025-07-11 20:06:00
+/v/kKy8aN,2,MIMK-200,2025-07-11 20:05:53,2025-07-11 20:05:53,,,,2025-07-11 20:05:53
+/v/AqKB2O,2,MIKR-028,2025-07-11 20:05:47,2025-07-11 20:05:47,,,,2025-07-11 20:05:47
+/v/ZNdw9V,2,MIDA-198,2025-07-11 20:05:40,2025-07-11 20:05:40,,,,2025-07-11 20:05:40
+/v/DRVgm3,2,ABF-247,2025-07-11 20:05:27,2025-07-11 20:05:27,,,,2025-07-11 20:05:27
+/v/a8yQXr,2,ABF-246,2025-07-11 20:05:21,2025-07-11 20:05:21,,,,2025-07-11 20:05:21
+/v/Mbq9GR,2,KBR-027,2025-07-11 20:05:14,2025-07-11 20:05:14,,,,2025-07-11 20:05:14
+/v/YwrdXb,2,MNGS-006,2025-07-11 20:05:08,2025-07-11 20:05:08,,,,2025-07-11 20:05:08
+/v/AqK7Oe,2,MIDA-241,2025-07-11 20:05:01,2025-07-11 20:05:01,,,,2025-07-11 20:05:01
+/v/WwVNmq,2,MIDA-234,2025-07-11 20:04:55,2025-07-11 20:04:55,,,,2025-07-11 20:04:55
+/v/7yq7OP,2,MIMK-217,2025-07-11 20:04:48,2025-07-11 20:04:48,,,,2025-07-11 20:04:48
+/v/kKy2nV,2,PRED-785,2025-07-11 20:04:42,2025-07-11 20:04:42,,,,2025-07-11 20:04:42
+/v/DRVG82,1,SONE-790,2025-07-05 22:10:13,2025-07-11 20:02:34,2025-07-11 20:02:34,,2025-07-11 20:02:34,2025-07-11 20:02:34
+/v/mOJWnD,1,SONE-746,2025-07-05 22:10:47,2025-07-11 20:02:28,2025-07-11 20:02:28,,2025-07-11 20:02:28,2025-07-11 20:02:28
+/v/mOJqwZ,1,JUR-415,2025-07-11 20:02:21,2025-07-11 20:02:21,,,2025-07-11 20:02:21,
+/v/a8yNqp,1,JUR-407,2025-07-05 22:11:29,2025-07-11 20:02:09,,,2025-07-11 20:02:09,2025-07-11 20:02:09
+/v/4Dd98p,1,JUR-400,2025-07-11 20:02:02,2025-07-11 20:02:02,,,2025-07-11 20:02:02,
+/v/DRVkWa,1,JUR-397,2025-07-06 21:00:13,2025-07-11 20:01:55,,,2025-07-11 20:01:55,2025-07-11 20:01:55
+/v/ve0xOG,1,JUR-395,2025-07-11 20:01:49,2025-07-11 20:01:49,,,2025-07-11 20:01:49,
+/v/YwrkZd,1,JUR-380,2025-07-09 20:05:05,2025-07-11 20:01:43,2025-07-11 20:01:43,,2025-07-11 20:01:43,2025-07-11 20:01:43
+/v/ZNdApJ,1,JUR-370,2025-07-05 22:10:31,2025-07-11 20:01:36,2025-07-11 20:01:36,,2025-07-11 20:01:36,2025-07-11 20:01:36
+/v/pkqXOB,1,JUR-364,2025-07-06 21:00:37,2025-07-11 20:01:30,,,2025-07-11 20:01:30,2025-07-11 20:01:30
+/v/kKyz36,1,JUR-333,2025-07-06 21:02:22,2025-07-11 20:01:23,,,2025-07-11 20:01:23,2025-07-11 20:01:23
+/v/mOJqy5,1,JUR-047,2025-07-05 22:11:26,2025-07-11 20:01:17,,,2025-07-11 20:01:17,2025-07-11 20:01:17
+/v/WwVrrQ,1,MFYD-011,2025-07-11 20:01:10,2025-07-11 20:01:10,,2025-07-11 20:01:10,2025-07-11 20:01:10,
+/v/veZydn,1,MEYD-998,2025-07-11 20:01:04,2025-07-11 20:01:04,,2025-07-11 20:01:04,2025-07-11 20:01:04,
+/v/qDx13,1,MEYD-280,2025-07-11 20:00:57,2025-07-11 20:00:57,,2025-07-11 20:00:57,2025-07-11 20:00:57,
+/v/Bzg969,2,GVH-757,2025-07-10 20:06:00,2025-07-10 20:06:00,,,,2025-07-10 20:06:00
+/v/ZNdJ5P,2,AKDL-331,2025-07-10 20:05:48,2025-07-10 20:05:48,,,,2025-07-10 20:05:48
+/v/pkqev9,2,GNSZ-001,2025-07-10 20:05:41,2025-07-10 20:05:41,,,,2025-07-10 20:05:41
+/v/AqK23y,2,PJAB-012,2025-07-10 20:05:35,2025-07-10 20:05:35,,,,2025-07-10 20:05:35
+/v/pkqeeq,2,MANX-014,2025-07-10 00:02:35,2025-07-10 20:05:17,,2025-07-10 20:05:17,,2025-07-10 20:05:17
+/v/JrQeq,2,KNAM-056,2025-07-10 20:05:11,2025-07-10 20:05:11,,2025-07-10 20:05:11,,2025-07-10 20:05:11
+/v/ZNd9bX,2,JUVR-234,2025-07-10 00:02:29,2025-07-10 20:05:04,,2025-07-10 20:05:04,,2025-07-10 20:05:04
+/v/96qAvX,2,MFCS-172,2025-07-10 20:04:58,2025-07-10 20:04:58,,,,2025-07-10 20:04:58
+/v/1A45yn,2,DAM-057,2025-07-10 20:04:41,2025-07-10 20:04:41,,,,2025-07-10 20:04:41
+/v/YwrppB,2,START-347,2025-07-10 20:04:34,2025-07-10 20:04:34,,,,2025-07-10 20:04:34
+/v/DRVp4p,2,MIUM-1256,2025-07-10 20:04:28,2025-07-10 20:04:28,,,,2025-07-10 20:04:28
+/v/pkxpvw,2,MDVR-344,2025-07-10 20:04:16,2025-07-10 20:04:16,,2025-07-10 20:04:16,,
+/v/xAgmKn,1,SONE-812,2025-07-10 20:02:20,2025-07-10 20:02:20,,,2025-07-10 20:02:20,
+/v/82qAYV,1,SONE-808,2025-07-06 21:00:25,2025-07-10 20:02:13,,,2025-07-10 20:02:13,2025-07-10 20:02:13
+/v/96qmZ6,1,SONE-807,2025-07-05 22:10:35,2025-07-10 20:02:07,,,2025-07-10 20:02:07,2025-07-10 20:02:07
+/v/kKy87e,1,SONE-793,2025-07-05 22:10:32,2025-07-10 20:02:00,2025-07-10 20:02:00,,2025-07-10 20:02:00,2025-07-10 20:02:00
+/v/YwrOPe,1,SONE-758,2025-07-09 23:58:59,2025-07-10 20:01:47,2025-07-10 20:01:47,,2025-07-10 20:01:47,
+/v/AqKB8n,1,SONE-753,2025-07-10 20:01:41,2025-07-10 20:01:41,,,2025-07-10 20:01:41,
+/v/AqK8WO,1,IPZZ-647,2025-07-10 20:01:28,2025-07-10 20:01:28,,,2025-07-10 20:01:28,
+/v/Rk21OD,1,IPZZ-615,2025-07-10 20:01:21,2025-07-10 20:01:21,,,2025-07-10 20:01:21,
+/v/GZ4By5,1,IPZZ-607,2025-07-05 22:10:53,2025-07-10 20:01:08,,,2025-07-10 20:01:08,2025-07-10 20:01:08
+/v/gyqndG,1,IPZZ-599,2025-07-09 23:58:33,2025-07-10 20:01:02,2025-07-10 20:01:02,,2025-07-10 20:01:02,
+/v/MbqkvQ,2,JAC-218,2025-07-10 00:02:48,2025-07-10 00:02:48,,,,2025-07-10 00:02:48
+/v/BzgBWO,2,MFCW-053,2025-07-10 00:02:23,2025-07-10 00:02:23,,,,2025-07-10 00:02:23
+/v/kKyNkJ,2,AKDL-332,2025-07-10 00:02:16,2025-07-10 00:02:16,,,,2025-07-10 00:02:16
+/v/WwVNeQ,1,SONE-805,2025-07-09 23:59:25,2025-07-09 23:59:25,,,2025-07-09 23:59:25,
+/v/a8yn0X,1,SONE-804,2025-07-09 23:59:19,2025-07-09 23:59:19,,,2025-07-09 23:59:19,
+/v/4DdP2b,1,SONE-798,2025-07-09 23:59:12,2025-07-09 23:59:12,,,2025-07-09 23:59:12,
+/v/0edX1J,1,SONE-795,2025-07-09 23:59:06,2025-07-09 23:59:06,,,2025-07-09 23:59:06,
+/v/degnW0,1,IPZZ-604,2025-07-09 23:58:53,2025-07-09 23:58:53,,,2025-07-09 23:58:53,
+/v/Bzg9G6,1,IPZZ-602,2025-07-09 23:58:46,2025-07-09 23:58:46,,,2025-07-09 23:58:46,
+/v/wKkAPz,1,IPZZ-601,2025-07-09 23:58:40,2025-07-09 23:58:40,,,2025-07-09 23:58:40,
+/v/3nrDY9,1,IPZZ-575,2025-07-09 23:58:26,2025-07-09 23:58:26,2025-07-09 23:58:26,,2025-07-09 23:58:26,
+/v/mOJnXY,1,IPZZ-574,2025-07-09 23:58:20,2025-07-09 23:58:20,2025-07-09 23:58:20,,2025-07-09 23:58:20,
+/v/96qBv8,2,NGOD-272,2025-07-08 20:06:00,2025-07-08 20:06:00,,,,2025-07-08 20:06:00
+/v/z458vJ,2,APGH-039,2025-07-08 20:05:24,2025-07-08 20:05:24,,,,2025-07-08 20:05:24
+/v/a8ynA3,2,LULU-384,2025-07-08 20:05:18,2025-07-08 20:05:18,,,,2025-07-08 20:05:18
+/v/Ywrbxb,2,FLAV-398,2025-07-08 20:05:11,2025-07-08 20:05:11,,,,2025-07-08 20:05:11
+/v/z450kQ,2,SIRO-5499,2025-07-08 20:05:05,2025-07-08 20:05:05,,,,2025-07-08 20:05:05
+/v/ne4aA9,1,MIDV-247,2025-07-08 20:02:58,2025-07-08 20:02:58,2025-07-08 20:02:58,,2025-07-08 20:02:58,
+/v/RdJmPD,1,MIDV-228,2025-07-08 20:02:51,2025-07-08 20:02:51,2025-07-08 20:02:51,,2025-07-08 20:02:51,
+/v/XWqb01,1,MIDV-206,2025-07-08 20:02:45,2025-07-08 20:02:45,2025-07-08 20:02:45,,2025-07-08 20:02:45,
+/v/DR4Jp3,1,FTHTD-094,2025-07-08 20:02:38,2025-07-08 20:02:38,,,2025-07-08 20:02:38,
+/v/xAgmwB,1,FPRE-184,2025-07-08 20:02:32,2025-07-08 20:02:32,,,2025-07-08 20:02:32,
+/v/NQPOqx,1,FPRE-183,2025-07-08 20:02:26,2025-07-08 20:02:26,,,2025-07-08 20:02:26,
+/v/a8ypZX,1,FOCS-257,2025-07-08 20:02:19,2025-07-08 20:02:19,,,2025-07-08 20:02:19,
+/v/V4NpVD,1,FERA-200,2025-07-08 20:02:13,2025-07-08 20:02:13,,,2025-07-08 20:02:13,
+/v/Rk2Jv4,1,EUUD-067,2025-07-08 20:02:06,2025-07-08 20:02:06,,,2025-07-08 20:02:06,
+/v/xAgN9P,1,EUUD-066,2025-07-08 20:02:00,2025-07-08 20:02:00,,,2025-07-08 20:02:00,
+/v/BzKNP1,1,EUUD-065,2025-07-08 20:01:53,2025-07-08 20:01:53,,,2025-07-08 20:01:53,
+/v/xAgmO6,1,DVEH-056,2025-07-08 20:01:47,2025-07-08 20:01:47,,,2025-07-08 20:01:47,
+/v/wKpWke,1,DVEH-054,2025-07-08 20:01:41,2025-07-08 20:01:41,,,2025-07-08 20:01:41,
+/v/82X7Z3,1,JUR-197,2025-07-08 20:01:34,2025-07-08 20:01:34,2025-07-08 20:01:34,,2025-07-08 20:01:34,
+/v/XzOrG,1,JUL-300,2025-07-08 20:01:28,2025-07-08 20:01:28,,2025-07-08 20:01:28,2025-07-08 20:01:28,
+/v/mbRwD,1,JUL-142,2025-07-08 20:01:21,2025-07-08 20:01:21,,2025-07-08 20:01:21,2025-07-08 20:01:21,
+/v/XeqeGJ,1,JUFE-583,2025-07-08 20:01:15,2025-07-08 20:01:15,,2025-07-08 20:01:15,2025-07-08 20:01:15,
+/v/KeV6,1,IPZ-826,2025-07-08 20:01:08,2025-07-08 20:01:08,2025-07-08 20:01:08,,2025-07-08 20:01:08,
+/v/bNWA,1,IPZ-700,2025-07-08 20:01:02,2025-07-08 20:01:02,,2025-07-08 20:01:02,2025-07-08 20:01:02,
+/v/J00yx,1,IPZ-166,2025-07-08 20:00:55,2025-07-08 20:00:55,,2025-07-08 20:00:55,2025-07-08 20:00:55,
+/v/6dqGZ0,2,MKMP-650,2025-07-07 20:05:45,2025-07-07 20:05:45,,,,2025-07-07 20:05:45
+/v/J06Yg8,2,ROE-386,2025-07-07 20:05:27,2025-07-07 20:05:27,,,,2025-07-07 20:05:27
+/v/p33M9,2,HBAD-338,2025-07-07 20:05:21,2025-07-07 20:05:21,,2025-07-07 20:05:21,,2025-07-07 20:05:21
+/v/wKkaRB,2,DOKS-641,2025-07-07 20:05:03,2025-07-07 20:05:03,,,,2025-07-07 20:05:03
+/v/mOJk9v,2,MDVR-351,2025-07-07 20:04:51,2025-07-07 20:04:51,,,,2025-07-07 20:04:51
+/v/G8dAb,2,HZGD-175,2025-07-07 20:04:34,2025-07-07 20:04:34,,2025-07-07 20:04:34,,2025-07-07 20:04:34
+/v/Mbq8gA,2,HMN-708,2025-07-07 20:04:27,2025-07-07 20:04:27,,2025-07-07 20:04:27,,2025-07-07 20:04:27
+/v/wKkAr1,1,WAAA-543,2025-07-07 20:02:09,2025-07-07 20:02:09,,,2025-07-07 20:02:09,
+/v/yx4RbZ,1,WAAA-542,2025-07-07 20:02:02,2025-07-07 20:02:02,,,2025-07-07 20:02:02,
+/v/gyqnME,1,WAAA-541,2025-07-07 20:01:56,2025-07-07 20:01:56,,,2025-07-07 20:01:56,
+/v/r3YZdJ,1,WAAA-539,2025-07-07 20:01:49,2025-07-07 20:01:49,,,2025-07-07 20:01:49,
+/v/NQPOnN,1,WAAA-537,2025-07-07 20:01:43,2025-07-07 20:01:43,,,2025-07-07 20:01:43,
+/v/degn8M,1,WAAA-536,2025-07-07 20:01:36,2025-07-07 20:01:36,,,2025-07-07 20:01:36,
+/v/YwrO3p,1,WAAA-511,2025-07-07 20:01:30,2025-07-07 20:01:30,2025-07-07 20:01:30,,2025-07-07 20:01:30,
+/v/yx4RPZ,1,VENX-326,2025-07-07 20:01:23,2025-07-07 20:01:23,,,2025-07-07 20:01:23,
+/v/7yqdPB,1,VENX-325,2025-07-07 20:01:17,2025-07-07 20:01:17,,,2025-07-07 20:01:17,
+/v/2d3zy,1,IPX-899,2025-07-07 20:01:10,2025-07-07 20:01:10,,2025-07-07 20:01:10,2025-07-07 20:01:10,
+/v/W5bn8,1,IPX-793,2025-07-07 20:01:04,2025-07-07 20:01:04,,2025-07-07 20:01:04,2025-07-07 20:01:04,
+/v/yVgJg,1,IPIT-024,2025-07-07 20:00:57,2025-07-07 20:00:57,,2025-07-07 20:00:57,2025-07-07 20:00:57,
+/v/AqK13n,2,START-345,2025-07-06 21:05:19,2025-07-06 21:05:19,,,,2025-07-06 21:05:19
+/v/96q3DV,2,DLDSS-406,2025-07-06 21:04:56,2025-07-06 21:04:56,,,,2025-07-06 21:04:56
+/v/nKz6ee,2,MGOLD-037,2025-07-06 21:04:50,2025-07-06 21:04:50,,,,2025-07-06 21:04:50
+/v/mOJqAR,2,NGOD-275,2025-07-06 21:04:21,2025-07-06 21:04:21,,,,2025-07-06 21:04:21
+/v/a8yQ5r,2,DRPT-091,2025-07-06 21:04:15,2025-07-06 21:04:15,,,,2025-07-06 21:04:15
+/v/z45Y8J,2,ROE-377,2025-07-06 21:04:03,2025-07-06 21:04:03,,,,2025-07-06 21:04:03
+/v/1A4OBJ,2,FNS-077,2025-07-06 21:03:21,2025-07-06 21:03:21,,2025-07-06 21:03:21,,2025-07-06 21:03:21
+/v/1A4m8w,2,JUR-396,2025-07-06 21:02:45,2025-07-06 21:02:45,,,,2025-07-06 21:02:45
+/v/a8ynOX,2,DASS-679,2025-07-06 21:01:54,2025-07-06 21:01:54,,,,2025-07-06 21:01:54
+/v/bKw2kB,2,AVSA-388,2025-07-06 21:01:42,2025-07-06 21:01:42,,,,2025-07-06 21:01:42
+/v/Xe4JqG,2,SAVR-663,2025-07-06 21:01:29,2025-07-06 21:01:29,,,,2025-07-06 21:01:29
+/v/Eb6Awx,2,MKMP-649,2025-07-06 21:01:12,2025-07-06 21:01:12,,,,2025-07-06 21:01:12
+/v/bKwYvP,2,HZGD-310,2025-07-06 21:00:43,2025-07-06 21:00:43,,,,2025-07-06 21:00:43
+/v/3nrZDb,2,REAL-922,2025-07-06 20:59:55,2025-07-06 20:59:55,,,,2025-07-06 20:59:55
+/v/e8OnRd,2,ALDN-480,2025-07-06 20:59:48,2025-07-06 20:59:48,,,,2025-07-06 20:59:48
+/v/e8OAkd,2,BAB-163,2025-07-06 20:59:42,2025-07-06 20:59:42,,,,2025-07-06 20:59:42
+/v/r3Y4Nv,1,PPPE-353,2025-07-06 20:57:13,2025-07-06 20:57:13,,,2025-07-06 20:57:13,
+/v/5nXb5D,1,PPPE-350,2025-07-06 20:57:06,2025-07-06 20:57:06,,,2025-07-06 20:57:06,
+/v/bKwOVv,1,PPPE-348,2025-07-06 20:57:00,2025-07-06 20:57:00,,,2025-07-06 20:57:00,
+/v/Xe4V05,1,PPPE-346,2025-07-06 20:56:53,2025-07-06 20:56:53,,,2025-07-06 20:56:53,
+/v/QNWrq4,1,PPPE-345,2025-07-06 20:56:47,2025-07-06 20:56:47,,,2025-07-06 20:56:47,
+/v/mOpM9Z,1,PFAS-033,2025-07-06 20:56:41,2025-07-06 20:56:41,,,2025-07-06 20:56:41,
+/v/5nXRkB,1,NTRD-125,2025-07-06 20:56:34,2025-07-06 20:56:34,,,2025-07-06 20:56:34,
+/v/wKkxWn,1,NSFS-393,2025-07-06 20:56:28,2025-07-06 20:56:28,,,2025-07-06 20:56:28,
+/v/5nXaz7,1,NSFS-392,2025-07-06 20:56:21,2025-07-06 20:56:21,,,2025-07-06 20:56:21,
+/v/QNW4XG,1,NPJS-201,2025-07-06 20:56:15,2025-07-06 20:56:15,,,2025-07-06 20:56:15,
+/v/AqK8Vw,1,MIDA-216,2025-07-06 20:56:08,2025-07-06 20:56:08,2025-07-06 20:56:08,,2025-07-06 20:56:08,
+/v/Rk26xp,1,JUR-381,2025-07-06 20:56:02,2025-07-06 20:56:02,2025-07-06 20:56:02,,2025-07-06 20:56:02,
+/v/J2nyW,1,HBAD-361,2025-07-06 20:55:55,2025-07-06 20:55:55,,2025-07-06 20:55:55,2025-07-06 20:55:55,
+/v/OXwmO,1,HBAD-345,2025-07-06 20:55:49,2025-07-06 20:55:49,,2025-07-06 20:55:49,2025-07-06 20:55:49,
+/v/RkJ2R,1,HBAD-342,2025-07-06 20:55:42,2025-07-06 20:55:42,,2025-07-06 20:55:42,2025-07-06 20:55:42,
+/v/dEkJe,2,GVG-813,2025-07-05 22:34:36,2025-07-05 22:34:36,,2025-07-05 22:34:36,,2025-07-05 22:34:36
+/v/K4ybQ,2,GVG-222,2025-07-05 22:34:34,2025-07-05 22:34:34,,2025-07-05 22:34:34,,2025-07-05 22:34:34
+/v/E931M,2,FOCS-071,2025-07-05 22:34:33,2025-07-05 22:34:33,,2025-07-05 22:34:33,,2025-07-05 22:34:33
+/v/96eO55,2,FNS-038,2025-07-05 22:34:31,2025-07-05 22:34:31,,2025-07-05 22:34:31,,2025-07-05 22:34:31
+/v/3nrZMz,1,FNS-045,2025-07-05 22:33:36,2025-07-05 22:33:36,,,2025-07-05 22:33:36,
+/v/Rk216D,1,ADN-696,2025-07-05 22:33:30,2025-07-05 22:33:30,2025-07-05 22:33:30,,2025-07-05 22:33:30,
+/v/Mbq3m1,1,FNS-046,2025-07-05 22:31:51,2025-07-05 22:31:51,,2025-07-05 22:31:51,2025-07-05 22:31:51,
+/v/V4Nx7X,1,CAWD-858,2025-07-05 22:20:10,2025-07-05 22:20:10,,,2025-07-05 22:20:10,
+/v/z458V5,1,CAWD-856,2025-07-05 22:20:09,2025-07-05 22:20:09,,,2025-07-05 22:20:09,
+/v/6dqNXE,1,ABF-241,2025-07-05 22:20:07,2025-07-05 22:20:07,2025-07-05 22:20:07,,2025-07-05 22:20:07,
+/v/YwrB2p,1,DLDSS-403,2025-07-05 22:20:06,2025-07-05 22:20:06,,2025-07-05 22:20:06,2025-07-05 22:20:06,
+/v/AqKaz0,1,FNS-039,2025-07-05 22:20:04,2025-07-05 22:20:04,,,2025-07-05 22:20:04,
+/v/pkq639,1,FNS-048,2025-07-05 22:20:03,2025-07-05 22:20:03,,,2025-07-05 22:20:03,
+/v/ve06Dp,1,FNS-052,2025-07-05 22:20:01,2025-07-05 22:20:01,,,2025-07-05 22:20:01,
+/v/82ErvV,1,LUCY-012,2025-07-05 22:20:00,2025-07-05 22:20:00,,,2025-07-05 22:20:00,
+/v/veZQ5p,1,LUCY-011,2025-07-05 22:19:58,2025-07-05 22:19:58,,,2025-07-05 22:19:58,
+/v/YwqNB8,1,LUCY-010,2025-07-05 22:19:57,2025-07-05 22:19:57,,,2025-07-05 22:19:57,
+/v/NQ9Mgx,1,LUCY-007,2025-07-05 22:19:55,2025-07-05 22:19:55,,,2025-07-05 22:19:55,
+/v/wKY2V2,1,LUCY-006,2025-07-05 22:19:54,2025-07-05 22:19:54,,,2025-07-05 22:19:54,
+/v/96We6R,1,LUCY-004,2025-07-05 22:19:52,2025-07-05 22:19:52,,,2025-07-05 22:19:52,
+/v/WwVepg,1,JUTA-172,2025-07-05 22:19:51,2025-07-05 22:19:51,,,2025-07-05 22:19:51,
+/v/GZ4BNg,1,JUTA-171,2025-07-05 22:19:49,2025-07-05 22:19:49,,,2025-07-05 22:19:49,
+/v/bKwdO0,1,JRZE-248,2025-07-05 22:19:48,2025-07-05 22:19:48,,,2025-07-05 22:19:48,
+/v/Xe4vVb,1,JRZE-247,2025-07-05 22:19:46,2025-07-05 22:19:46,,,2025-07-05 22:19:46,
+/v/82qYB3,1,ADN-689,2025-07-05 22:19:43,2025-07-05 22:19:43,2025-07-05 22:19:43,,2025-07-05 22:19:43,
+/v/merpZ,1,GVG-270,2025-07-05 22:19:42,2025-07-05 22:19:42,,2025-07-05 22:19:42,2025-07-05 22:19:42,
+/v/GZ4BWb,2,MIUM-1240,2025-07-05 22:11:50,2025-07-05 22:11:50,,,,2025-07-05 22:11:50
+/v/7yqPVB,2,SAME-190,2025-07-05 22:11:48,2025-07-05 22:11:48,2025-07-05 22:11:48,,,2025-07-05 22:11:48
+/v/96q49R,2,EBWH-235,2025-07-05 22:11:47,2025-07-05 22:11:47,,2025-07-05 22:11:47,,2025-07-05 22:11:47
+/v/WwVVAg,2,EBWH-233,2025-07-05 22:11:45,2025-07-05 22:11:45,,2025-07-05 22:11:45,,2025-07-05 22:11:45
+/v/wdeOb,2,EBOD-853,2025-07-05 22:11:44,2025-07-05 22:11:44,,2025-07-05 22:11:44,,2025-07-05 22:11:44
+/v/yxr1Br,2,DPMI-091,2025-07-05 22:11:42,2025-07-05 22:11:42,,2025-07-05 22:11:42,,2025-07-05 22:11:42
+/v/d4B8OM,2,DPMI-082,2025-07-05 22:11:41,2025-07-05 22:11:41,,2025-07-05 22:11:41,,2025-07-05 22:11:41
+/v/E4Mp0,2,DGL-064,2025-07-05 22:11:40,2025-07-05 22:11:40,,2025-07-05 22:11:40,,2025-07-05 22:11:40
+/v/96qZMX,2,IPZZ-611,2025-07-05 22:11:38,2025-07-05 22:11:38,,,,2025-07-05 22:11:38
+/v/Mbqa81,2,MIUM-1244,2025-07-05 22:11:32,2025-07-05 22:11:32,,,,2025-07-05 22:11:32
+/v/qAJBY9,2,RKI-715,2025-07-05 22:11:28,2025-07-05 22:11:28,,,,2025-07-05 22:11:28
+/v/5nXPp9,2,IPZZ-596,2025-07-05 22:11:25,2025-07-05 22:11:25,,,,2025-07-05 22:11:25
+/v/2mqx5P,2,DASS-695,2025-07-05 22:11:23,2025-07-05 22:11:23,,,,2025-07-05 22:11:23
+/v/xAgmGn,2,DASS-682,2025-07-05 22:11:22,2025-07-05 22:11:22,,,,2025-07-05 22:11:22
+/v/1A437A,2,SONE-786,2025-07-05 22:11:20,2025-07-05 22:11:20,,,,2025-07-05 22:11:20
+/v/gyq5vq,2,SVVRT-065,2025-07-05 22:11:17,2025-07-05 22:11:17,,,,2025-07-05 22:11:17
+/v/KkKYrQ,2,START-322,2025-07-05 22:11:16,2025-07-05 22:11:16,,,,2025-07-05 22:11:16
+/v/P92kJN,2,START-355,2025-07-05 22:11:15,2025-07-05 22:11:15,,,,2025-07-05 22:11:15
+/v/7yq7YR,2,START-356,2025-07-05 22:11:13,2025-07-05 22:11:13,,,,2025-07-05 22:11:13
+/v/Eb67nM,2,SDJS-312,2025-07-05 22:11:12,2025-07-05 22:11:12,,,,2025-07-05 22:11:12
+/v/xAg2OV,2,START-372,2025-07-05 22:11:10,2025-07-05 22:11:10,,,,2025-07-05 22:11:10
+/v/a8yvVO,2,SDDE-754,2025-07-05 22:11:09,2025-07-05 22:11:09,,,,2025-07-05 22:11:09
+/v/Ywrd3K,2,SDNM-518,2025-07-05 22:11:07,2025-07-05 22:11:07,,,,2025-07-05 22:11:07
+/v/ZNdB3X,2,MOGI-139,2025-07-05 22:11:06,2025-07-05 22:11:06,,,,2025-07-05 22:11:06
+/v/ZNdgbq,2,START-358,2025-07-05 22:11:04,2025-07-05 22:11:04,,,,2025-07-05 22:11:04
+/v/pkqy0q,2,START-354,2025-07-05 22:11:03,2025-07-05 22:11:03,,,,2025-07-05 22:11:03
+/v/MbqkR4,2,START-352,2025-07-05 22:11:01,2025-07-05 22:11:01,,,,2025-07-05 22:11:01
+/v/kKyGxe,2,START-349,2025-07-05 22:11:00,2025-07-05 22:11:00,,,,2025-07-05 22:11:00
+/v/82q1vW,2,START-331,2025-07-05 22:10:58,2025-07-05 22:10:58,,,,2025-07-05 22:10:58
+/v/Xe4xM4,2,ABF-245,2025-07-05 22:10:55,2025-07-05 22:10:55,,,,2025-07-05 22:10:55
+/v/YwrBOe,2,SONE-803,2025-07-05 22:10:54,2025-07-05 22:10:54,,,,2025-07-05 22:10:54
+/v/qAJYk9,2,DASS-704,2025-07-05 22:10:51,2025-07-05 22:10:51,,,,2025-07-05 22:10:51
+/v/V4Nx5A,2,IPZZ-383,2025-07-05 22:10:45,2025-07-05 22:10:45,,,,2025-07-05 22:10:45
+/v/ve0kgW,2,SONE-780,2025-07-05 22:10:44,2025-07-05 22:10:44,,,,2025-07-05 22:10:44
+/v/MbqM14,2,SONE-796,2025-07-05 22:10:34,2025-07-05 22:10:34,,,,2025-07-05 22:10:34
+/v/Mbqd4P,2,JUR-361,2025-07-05 22:10:29,2025-07-05 22:10:29,,,,2025-07-05 22:10:29
+/v/0edA6b,2,JUR-334,2025-07-05 22:10:28,2025-07-05 22:10:28,,,,2025-07-05 22:10:28
+/v/AqKpkP,2,JUR-331,2025-07-05 22:10:26,2025-07-05 22:10:26,,,,2025-07-05 22:10:26
+/v/ve0xJ8,2,MADV-592,2025-07-05 22:10:25,2025-07-05 22:10:25,,,,2025-07-05 22:10:25
+/v/yx4Reb,2,IPZZ-600,2025-07-05 22:10:22,2025-07-05 22:10:22,,,,2025-07-05 22:10:22
+/v/DRVGB2,2,DASS-657,2025-07-05 22:10:21,2025-07-05 22:10:21,,,,2025-07-05 22:10:21
+/v/ZNdwOq,2,SONE-802,2025-07-05 22:10:19,2025-07-05 22:10:19,,,,2025-07-05 22:10:19
+/v/pkqdnq,2,SONE-800,2025-07-05 22:10:18,2025-07-05 22:10:18,,,,2025-07-05 22:10:18
+/v/Mbq1O1,2,GVH-755,2025-07-05 22:10:12,2025-07-05 22:10:12,,,,2025-07-05 22:10:12
+/v/e8OM5M,1,FNS-074,2025-07-05 22:09:20,2025-07-05 22:09:20,,,2025-07-05 22:09:20,
+/v/Xe4DOP,2,MDON-077,2025-07-04 20:01:55,2025-07-04 20:01:55,,,,2025-07-04 20:01:55
+/v/QNW4eG,2,SQTE-617,2025-07-04 20:01:54,2025-07-04 20:01:54,,,,2025-07-04 20:01:54
+/v/ve0yK9,2,SUJI-279,2025-07-04 20:01:52,2025-07-04 20:01:52,,,,2025-07-04 20:01:52
+/v/Mbqnxv,2,MAAN-1077,2025-07-04 20:01:51,2025-07-04 20:01:51,,,,2025-07-04 20:01:51
+/v/e8OnPp,2,SAME-187,2025-07-04 20:01:49,2025-07-04 20:01:49,2025-07-04 20:01:49,,,2025-07-04 20:01:49
+/v/DRVWDM,2,BLK-653,2025-07-04 20:01:48,2025-07-04 20:01:48,,2025-07-04 20:01:48,,2025-07-04 20:01:48
+/v/MbqP2Q,2,MIUM-1223,2025-07-04 20:01:46,2025-07-04 20:01:46,,,,2025-07-04 20:01:46
+/v/ZNd5n6,2,LUXU-1843,2025-07-04 20:01:45,2025-07-04 20:01:45,,,,2025-07-04 20:01:45
+/v/V4Nk0n,2,DCV-280,2025-07-04 20:01:43,2025-07-04 20:01:43,,,,2025-07-04 20:01:43
+/v/bKwbNg,2,ABF-243,2025-07-04 20:01:42,2025-07-04 20:01:42,,,,2025-07-04 20:01:42
+/v/WwVepR,1,MIDA-223,2025-07-04 20:00:52,2025-07-04 20:00:52,,,2025-07-04 20:00:52,
+/v/Mbq17R,1,MIDA-222,2025-07-04 20:00:51,2025-07-04 20:00:51,,,2025-07-04 20:00:51,
+/v/P92Ov9,1,MIDA-221,2025-07-04 20:00:49,2025-07-04 20:00:49,,,2025-07-04 20:00:49,
+/v/kKy7Dm,1,MIDA-217,2025-07-04 20:00:47,2025-07-04 20:00:47,,,2025-07-04 20:00:47,
+/v/ZNdORJ,1,MIDA-215,2025-07-04 20:00:44,2025-07-04 20:00:44,,,2025-07-04 20:00:44,
+/v/Rk218z,1,MIDA-212,2025-07-04 20:00:42,2025-07-04 20:00:42,,,2025-07-04 20:00:42,
+/v/Mbq17v,1,ADN-714,2025-07-04 20:00:41,2025-07-04 20:00:41,,,2025-07-04 20:00:41,
+/v/xaz9B,1,DASD-926,2025-07-04 20:00:39,2025-07-04 20:00:39,,2025-07-04 20:00:39,2025-07-04 20:00:39,
+/v/e8OnDN,1,CAWD-845,2025-07-04 20:00:25,2025-07-04 20:00:25,2025-07-04 20:00:25,,2025-07-04 20:00:25,
+/v/KkKDy6,2,JAC-220,2025-07-03 20:01:30,2025-07-03 20:01:30,,,,2025-07-03 20:01:30
+/v/96q556,2,BDST-066,2025-07-03 20:01:28,2025-07-03 20:01:28,,,,2025-07-03 20:01:28
+/v/D22yV2,2,BACJ-022,2025-07-03 20:01:25,2025-07-03 20:01:25,,2025-07-03 20:01:25,,2025-07-03 20:01:25
+/v/1QWOJ,2,ATID-482,2025-07-03 20:01:24,2025-07-03 20:01:24,,2025-07-03 20:01:24,,2025-07-03 20:01:24
+/v/Nrgrr,2,APAK-227,2025-07-03 20:01:22,2025-07-03 20:01:22,,2025-07-03 20:01:22,,2025-07-03 20:01:22
+/v/V4NDxq,2,START-368,2025-07-03 20:01:21,2025-07-03 20:01:21,,,,2025-07-03 20:01:21
+/v/P92Dw9,2,START-353,2025-07-03 20:01:19,2025-07-03 20:01:19,,,,2025-07-03 20:01:19
+/v/xAgb18,2,DDOB-140,2025-07-03 20:01:18,2025-07-03 20:01:18,,,,2025-07-03 20:01:18
+/v/0edmE3,2,LUXU-1842,2025-07-03 20:01:16,2025-07-03 20:01:16,,,,2025-07-03 20:01:16
+/v/5nXbY6,1,ALDN-478,2025-07-03 20:00:48,2025-07-03 20:00:48,,,2025-07-03 20:00:48,
+/v/bKwOkg,1,ALDN-477,2025-07-03 20:00:47,2025-07-03 20:00:47,,,2025-07-03 20:00:47,
+/v/Xe4V34,1,ALDN-476,2025-07-03 20:00:46,2025-07-03 20:00:46,,,2025-07-03 20:00:46,
+/v/mOJnDY,1,ADN-703,2025-07-03 20:00:44,2025-07-03 20:00:44,,,2025-07-03 20:00:44,
+/v/96qZnX,1,ADN-683,2025-07-03 20:00:40,2025-07-03 20:00:40,,,2025-07-03 20:00:40,
+/v/WwVe7q,1,ADN-667,2025-07-03 20:00:38,2025-07-03 20:00:38,,,2025-07-03 20:00:38,
+/v/762Od,1,ATID-284,2025-07-03 20:00:35,2025-07-03 20:00:35,,2025-07-03 20:00:35,2025-07-03 20:00:35,
+/v/mezran,1,ALDN-136,2025-07-03 20:00:34,2025-07-03 20:00:34,,2025-07-03 20:00:34,2025-07-03 20:00:34,
+/v/0ed123,1,MIDA-220,2025-07-03 20:00:28,2025-07-03 20:00:28,2025-07-03 20:00:28,,2025-07-03 20:00:28,
+/v/mOJnDM,1,MIDA-213,2025-07-03 20:00:22,2025-07-03 20:00:22,2025-07-03 20:00:22,,2025-07-03 20:00:22,
+/v/r3Yrnr,2,NMSL-009,2025-07-02 20:01:44,2025-07-02 20:01:44,,,,2025-07-02 20:01:44
+/v/82qg0K,2,GANA-3223,2025-07-02 20:01:42,2025-07-02 20:01:42,,,,2025-07-02 20:01:42
+/v/deg32Q,2,KIRM-055,2025-07-02 20:01:41,2025-07-02 20:01:41,,,,2025-07-02 20:01:41
+/v/YwrO48,2,SMOK-017,2025-07-02 20:01:39,2025-07-02 20:01:39,,,,2025-07-02 20:01:39
+/v/z45877,2,SORA-602,2025-07-02 20:01:38,2025-07-02 20:01:38,,,,2025-07-02 20:01:38
+/v/96q2kE,2,MIUM-1217,2025-07-02 20:01:37,2025-07-02 20:01:37,,,,2025-07-02 20:01:37
+/v/g0w8q,2,ABP-438,2025-07-02 20:01:35,2025-07-02 20:01:35,,2025-07-02 20:01:35,,2025-07-02 20:01:35
+/v/yr2v0,2,ABP-421,2025-07-02 20:01:34,2025-07-02 20:01:34,,2025-07-02 20:01:34,,2025-07-02 20:01:34
+/v/6dqORK,2,OLM-208,2025-07-02 20:01:32,2025-07-02 20:01:32,,,,2025-07-02 20:01:32
+/v/96qr2w,2,TDAN-009,2025-07-02 20:01:31,2025-07-02 20:01:31,,,,2025-07-02 20:01:31
+/v/e8OYnp,1,VEC-710,2025-07-02 20:00:59,2025-07-02 20:00:59,,,2025-07-02 20:00:59,
+/v/qAJGYP,1,VEC-709,2025-07-02 20:00:58,2025-07-02 20:00:58,,,2025-07-02 20:00:58,
+/v/2mq8xq,1,VEC-708,2025-07-02 20:00:56,2025-07-02 20:00:56,,,2025-07-02 20:00:56,
+/v/6dqwxD,1,ROE-367,2025-07-02 20:00:55,2025-07-02 20:00:55,,,2025-07-02 20:00:55,
+/v/Eb6mZd,1,ROE-362,2025-07-02 20:00:53,2025-07-02 20:00:53,,,2025-07-02 20:00:53,
+/v/xAgPDg,1,ROE-360,2025-07-02 20:00:52,2025-07-02 20:00:52,,,2025-07-02 20:00:52,
+/v/a8ym4q,1,ROE-359,2025-07-02 20:00:50,2025-07-02 20:00:50,,,2025-07-02 20:00:50,
+/v/4DdnVG,1,ROE-356,2025-07-02 20:00:49,2025-07-02 20:00:49,,,2025-07-02 20:00:49,
+/v/DRVAYK,1,ROE-354,2025-07-02 20:00:47,2025-07-02 20:00:47,,,2025-07-02 20:00:47,
+/v/MbYJ8Q,1,REAL-916,2025-07-02 20:00:46,2025-07-02 20:00:46,,,2025-07-02 20:00:46,
+/v/zKQgXJ,1,ALDN-124,2025-07-02 20:00:44,2025-07-02 20:00:44,,2025-07-02 20:00:44,2025-07-02 20:00:44,
+/v/Mm6DzQ,1,ALDN-069,2025-07-02 20:00:43,2025-07-02 20:00:43,,2025-07-02 20:00:43,2025-07-02 20:00:43,
+/v/OXXE4y,1,ADN-610,2025-07-02 20:00:41,2025-07-02 20:00:41,,2025-07-02 20:00:41,2025-07-02 20:00:41,
+/v/bAVD3g,1,ADN-539,2025-07-02 20:00:40,2025-07-02 20:00:40,,2025-07-02 20:00:40,2025-07-02 20:00:40,
+/v/67x8D,1,ADN-361,2025-07-02 20:00:38,2025-07-02 20:00:38,,2025-07-02 20:00:38,2025-07-02 20:00:38,
+/v/neYG6a,1,ABW-318,2025-07-02 20:00:37,2025-07-02 20:00:37,,2025-07-02 20:00:37,2025-07-02 20:00:37,
+/v/V7v7n,1,ABP-968,2025-07-02 20:00:35,2025-07-02 20:00:35,,2025-07-02 20:00:35,2025-07-02 20:00:35,
+/v/YwrO3B,1,ATID-637,2025-07-02 20:00:34,2025-07-02 20:00:34,2025-07-02 20:00:34,,2025-07-02 20:00:34,
+/v/0edZvq,2,MAAN-1086,2025-07-01 21:01:56,2025-07-01 21:01:56,,,,2025-07-01 21:01:56
+/v/Eb6pGd,2,NMSL-007,2025-07-01 21:01:54,2025-07-01 21:01:54,,,,2025-07-01 21:01:54
+/v/YwrgRD,2,JAC-219,2025-07-01 21:01:52,2025-07-01 21:01:52,,,,2025-07-01 21:01:52
+/v/kKYw8P,2,VDD-193,2025-07-01 21:01:51,2025-07-01 21:01:51,,2025-07-01 21:01:51,,2025-07-01 21:01:51
+/v/3nrOk0,2,SAN-362,2025-07-01 21:01:48,2025-07-01 21:01:48,,,,2025-07-01 21:01:48
+/v/mOJn8D,2,VDD-194,2025-07-01 21:01:47,2025-07-01 21:01:47,,,,2025-07-01 21:01:47
+/v/OXW6Vz,2,DVMM-263,2025-07-01 21:01:45,2025-07-01 21:01:45,,,,2025-07-01 21:01:45
+/v/QN0EBK,1,KSBJ-377,2025-07-01 21:01:11,2025-07-01 21:01:11,,,2025-07-01 21:01:11,
+/v/BzKz0O,1,KSBJ-372,2025-07-01 21:01:10,2025-07-01 21:01:10,,,2025-07-01 21:01:10,
+/v/yx0x3A,1,KSBJ-370,2025-07-01 21:01:08,2025-07-01 21:01:08,,,2025-07-01 21:01:08,
+/v/Kk2A2v,1,JUNY-157,2025-07-01 21:01:06,2025-07-01 21:01:06,,,2025-07-01 21:01:06,
+/v/AqEO3w,1,HUNTC-362,2025-07-01 21:01:05,2025-07-01 21:01:05,,,2025-07-01 21:01:05,
+/v/mOpGZM,1,HUNTC-352,2025-07-01 21:01:03,2025-07-01 21:01:03,,,2025-07-01 21:01:03,
+/v/96e506,1,HUNTC-331,2025-07-01 21:01:02,2025-07-01 21:01:02,,,2025-07-01 21:01:02,
+/v/Eb6Pe2,1,HUNTC-202,2025-07-01 21:01:00,2025-07-01 21:01:00,,,2025-07-01 21:01:00,
+/v/z45bqJ,1,HMN-714,2025-07-01 21:00:59,2025-07-01 21:00:59,,,2025-07-01 21:00:59,
+/v/P92Jza,1,HMN-698,2025-07-01 21:00:57,2025-07-01 21:00:57,,,2025-07-01 21:00:57,
+/v/qOXMN,1,CWPBD-09,2025-07-01 21:00:56,2025-07-01 21:00:56,,,2025-07-01 21:00:56,
+/v/BzK6rG,1,YUJ-040,2025-07-01 21:00:54,2025-07-01 21:00:54,,2025-07-01 21:00:54,2025-07-01 21:00:54,
+/v/GZdpDD,1,WAAA-540,2025-07-01 21:00:52,2025-07-01 21:00:52,,2025-07-01 21:00:52,2025-07-01 21:00:52,
+/v/82EvDK,1,WAAA-528,2025-07-01 21:00:50,2025-07-01 21:00:50,,2025-07-01 21:00:50,2025-07-01 21:00:50,
+/v/96eKJE,1,WAAA-526,2025-07-01 21:00:49,2025-07-01 21:00:49,,2025-07-01 21:00:49,2025-07-01 21:00:49,
+/v/Ww3g9g,1,WAAA-524,2025-07-01 21:00:48,2025-07-01 21:00:48,,2025-07-01 21:00:48,2025-07-01 21:00:48,
+/v/QMKY7,1,VENX-108,2025-07-01 21:00:46,2025-07-01 21:00:46,,2025-07-01 21:00:46,2025-07-01 21:00:46,
+/v/r3YZDk,2,FJIN-085,2025-06-30 21:01:43,2025-06-30 21:01:43,,,,2025-06-30 21:01:43
+/v/BzgnQG,2,MIUM-1239,2025-06-30 21:01:42,2025-06-30 21:01:42,,,,2025-06-30 21:01:42
+/v/nKz8Re,2,ARSO-2519,2025-06-30 21:01:40,2025-06-30 21:01:40,,,,2025-06-30 21:01:40
+/v/V4NxKq,2,MRSS-169,2025-06-30 21:01:39,2025-06-30 21:01:39,,,,2025-06-30 21:01:39
+/v/QNWy6J,2,HALE-064,2025-06-30 21:01:37,2025-06-30 21:01:37,,,,2025-06-30 21:01:37
+/v/qAOra,2,VDD-094,2025-06-30 21:01:36,2025-06-30 21:01:36,,2025-06-30 21:01:36,,2025-06-30 21:01:36
+/v/Xe4V55,2,START-336,2025-06-30 21:01:34,2025-06-30 21:01:34,,2025-06-30 21:01:34,,2025-06-30 21:01:34
+/v/NQP6Eg,2,START-327,2025-06-30 21:01:33,2025-06-30 21:01:33,,2025-06-30 21:01:33,,2025-06-30 21:01:33
+/v/GZ4nEz,2,START-299,2025-06-30 21:01:31,2025-06-30 21:01:31,,2025-06-30 21:01:31,,2025-06-30 21:01:31
+/v/MmVaPX,2,SONE-028,2025-06-30 21:01:30,2025-06-30 21:01:30,,2025-06-30 21:01:30,,2025-06-30 21:01:30
+/v/GZ4BG7,2,XVSR-823,2025-06-30 21:01:28,2025-06-30 21:01:28,,,,2025-06-30 21:01:28
+/v/NQPOrN,2,XVSR-822,2025-06-30 21:01:27,2025-06-30 21:01:27,,,,2025-06-30 21:01:27
+/v/Bzg9Ad,2,FKOU-002,2025-06-30 21:01:25,2025-06-30 21:01:25,,,,2025-06-30 21:01:25
+/v/wKkxK2,2,MAAN-1079,2025-06-30 21:01:24,2025-06-30 21:01:24,,,,2025-06-30 21:01:24
+/v/yx4Y1a,2,MIUM-1210,2025-06-30 21:01:23,2025-06-30 21:01:23,,,,2025-06-30 21:01:23
+/v/kKyaxJ,2,HNVR-147,2025-06-30 21:01:15,2025-06-30 21:01:15,,,,2025-06-30 21:01:15
+/v/Xe47kb,1,JUR-324,2025-06-30 21:00:37,2025-06-30 21:00:37,2025-06-30 21:00:37,,2025-06-30 21:00:37,
+/v/QNW7xM,1,JUR-316,2025-06-30 21:00:36,2025-06-30 21:00:36,2025-06-30 21:00:36,,2025-06-30 21:00:36,
+/v/4zR6,1,NTR-037,2025-06-30 21:00:22,2025-06-30 21:00:22,2025-06-30 21:00:22,,2025-06-30 21:00:22,
+/v/wKpW9e,1,YUJ-039,2025-06-30 21:00:20,2025-06-30 21:00:20,2025-06-30 21:00:20,,2025-06-30 21:00:20,
+/v/QNW47n,2,CLUB-877,2025-06-29 22:31:31,2025-06-29 22:31:31,,,,2025-06-29 22:31:31
+/v/OXW678,2,CAWD-854,2025-06-29 22:31:30,2025-06-29 22:31:30,,,,2025-06-29 22:31:30
+/v/ZNdO3V,2,MIMK-231,2025-06-29 22:31:27,2025-06-29 22:31:27,,,,2025-06-29 22:31:27
+/v/P92O79,2,SAME-191,2025-06-29 22:31:25,2025-06-29 22:31:25,,,,2025-06-29 22:31:25
+/v/J06gPA,2,CAWD-857,2025-06-29 22:31:21,2025-06-29 22:31:21,,,,2025-06-29 22:31:21
+/v/AqK8VO,2,ADN-705,2025-06-29 22:31:19,2025-06-29 22:31:19,,,,2025-06-29 22:31:19
+/v/96qZQ6,2,MIDA-133,2025-06-29 22:31:18,2025-06-29 22:31:18,,,,2025-06-29 22:31:18
+/v/xAgk4E,2,KIT-011,2025-06-29 22:31:17,2025-06-29 22:31:17,,,,2025-06-29 22:31:17
+/v/yx46Qr,2,LUXU-1841,2025-06-29 22:31:15,2025-06-29 22:31:15,,,,2025-06-29 22:31:15
+/v/GZ4b7m,2,SDHS-060,2025-06-29 22:31:14,2025-06-29 22:31:14,,,,2025-06-29 22:31:14
+/v/82qYza,2,MIMK-230,2025-06-29 22:31:11,2025-06-29 22:31:11,,,,2025-06-29 22:31:11
+/v/mOJRzd,2,HAWA-358,2025-06-29 22:31:09,2025-06-29 22:31:09,,,,2025-06-29 22:31:09
+/v/KkK0JO,2,HODV-2198,2025-06-29 22:31:03,2025-06-29 22:31:03,,,,2025-06-29 22:31:03
+/v/3nrDpa,2,MIAB-510,2025-06-29 22:31:02,2025-06-29 22:31:02,,,,2025-06-29 22:31:02
+/v/6dqPkE,2,MIAB-507,2025-06-29 22:31:00,2025-06-29 22:31:00,,,,2025-06-29 22:31:00
+/v/kKyDVP,1,JUR-401,2025-06-29 17:52:03,2025-06-29 17:52:03,,,2025-06-29 17:52:03,
+/v/AqKVxM,1,JUR-385,2025-06-29 17:52:01,2025-06-29 17:52:01,,,2025-06-29 17:52:01,
+/v/mOJDaR,1,JUR-382,2025-06-29 17:52:00,2025-06-29 17:52:00,,,2025-06-29 17:52:00,
+/v/pxAVq,1,n0996東熱に遥香見参！,2025-06-29 17:51:57,2025-06-29 17:51:57,,,2025-06-29 17:51:57,
+/v/NQZJ6B,1,FUGA-061,2025-06-29 17:51:54,2025-06-29 17:51:54,,,2025-06-29 17:51:54,
+/v/1AyQ4A,1,FUGA-060,2025-06-29 17:51:53,2025-06-29 17:51:53,,2025-06-29 17:51:53,2025-06-29 17:51:53,
+/v/Eb6GJJ,1,FERA-198,2025-06-29 17:51:51,2025-06-29 17:51:51,,,2025-06-29 17:51:51,
+/v/deRmQv,1,FERA-197,2025-06-29 17:51:50,2025-06-29 17:51:50,,,2025-06-29 17:51:50,
+/v/yx0KVg,1,DLDSS-408,2025-06-29 17:51:48,2025-06-29 17:51:48,,2025-06-29 17:51:48,2025-06-29 17:51:48,
+/v/4DdxXE,1,DASS-698,2025-06-29 17:51:45,2025-06-29 17:51:45,,,2025-06-29 17:51:45,
+/v/DRVnxJ,1,DASS-684,2025-06-29 17:51:44,2025-06-29 17:51:44,,,2025-06-29 17:51:44,
+/v/5nXbkD,1,START-333,2025-06-29 17:51:42,2025-06-29 17:51:42,,2025-06-29 17:51:42,2025-06-29 17:51:42,
+/v/9wP7E,1,STARS-345,2025-06-29 17:51:40,2025-06-29 17:51:40,,2025-06-29 17:51:40,2025-06-29 17:51:40,
+/v/YNVG6,1,STARS-342,2025-06-29 17:51:39,2025-06-29 17:51:39,,2025-06-29 17:51:39,2025-06-29 17:51:39,
+/v/WQqKq,2,OFJE-186,2025-06-29 17:40:29,2025-06-29 17:40:29,,,,2025-06-29 17:40:29
+/v/nn0W4,2,SSIS-163,2025-06-29 17:40:27,2025-06-29 17:40:27,,,,2025-06-29 17:40:27
+/v/b26Ae,2,SSIS-165,2025-06-29 17:40:26,2025-06-29 17:40:26,,,,2025-06-29 17:40:26
+/v/XO6WP,2,SSIS-164,2025-06-29 17:40:24,2025-06-29 17:40:24,,,,2025-06-29 17:40:24
+/v/kNXY4,2,SIVR-171,2025-06-29 17:40:23,2025-06-29 17:40:23,,,,2025-06-29 17:40:23
+/v/JK5Ez,2,OFJE-347,2025-06-29 17:40:21,2025-06-29 17:40:21,,,,2025-06-29 17:40:21
+/v/KOvE0,2,OAE-214,2025-06-29 17:40:20,2025-06-29 17:40:20,,,,2025-06-29 17:40:20
+/v/d6Mme,2,OFJE-3511,2025-06-29 17:40:18,2025-06-29 17:40:18,,,,2025-06-29 17:40:18
+/v/V37AQ,2,SIVR-191,2025-06-29 17:40:17,2025-06-29 17:40:17,,,,2025-06-29 17:40:17
+/v/QGmmp,2,SIVR-204,2025-06-29 17:40:15,2025-06-29 17:40:15,,,,2025-06-29 17:40:15
+/v/OndQz,2,SIVR-212,2025-06-29 17:40:14,2025-06-29 17:40:14,,,,2025-06-29 17:40:14
+/v/B8Kk49,2,SIVR-226,2025-06-29 17:40:13,2025-06-29 17:40:13,,,,2025-06-29 17:40:13
+/v/p3Onew,2,SIVR-231,2025-06-29 17:40:11,2025-06-29 17:40:11,,,,2025-06-29 17:40:11
+/v/9Dpywg,2,RBB-247,2025-06-29 17:40:10,2025-06-29 17:40:10,,,,2025-06-29 17:40:10
+/v/rmzmJr,2,OAE-228,2025-06-29 17:40:08,2025-06-29 17:40:08,,,,2025-06-29 17:40:08
+/v/PQwdka,2,SIVR-251,2025-06-29 17:40:07,2025-06-29 17:40:07,,,,2025-06-29 17:40:07
+/v/8VaNX5,2,SIVR-247,2025-06-29 17:40:05,2025-06-29 17:40:05,,,,2025-06-29 17:40:05
+/v/2ay9nm,2,SIVR-270,2025-06-29 17:40:04,2025-06-29 17:40:04,,,,2025-06-29 17:40:04
+/v/8V8G8W,2,SIVR-277,2025-06-29 17:40:02,2025-06-29 17:40:02,,,,2025-06-29 17:40:02
+/v/K43w5v,2,SIVR-293,2025-06-29 17:40:01,2025-06-29 17:40:01,,2025-06-29 17:40:01,,2025-06-29 17:40:01
+/v/AzDDVO,2,OFJE-431,2025-06-29 17:39:59,2025-06-29 17:39:59,,,,2025-06-29 17:39:59
+/v/Vw5ebW,2,SIVR-302,2025-06-29 17:39:58,2025-06-29 17:39:58,,2025-06-29 17:39:58,,2025-06-29 17:39:58
+/v/Yn6aXK,2,OAE-249,2025-06-29 17:39:56,2025-06-29 17:39:56,,,,2025-06-29 17:39:56
+/v/wKnOXe,2,SIVR-326,2025-06-29 17:39:55,2025-06-29 17:39:55,,,,2025-06-29 17:39:55
+/v/7yyPJd,2,SIVR-361,2025-06-29 17:39:53,2025-06-29 17:39:53,,,,2025-06-29 17:39:53
+/v/bKKbJv,2,OFJE-459,2025-06-29 17:39:52,2025-06-29 17:39:52,,,,2025-06-29 17:39:52
+/v/QNNwgG,2,OFJE-465,2025-06-29 17:39:50,2025-06-29 17:39:50,,,,2025-06-29 17:39:50
+/v/Mbba21,2,OFJE-470,2025-06-29 17:39:49,2025-06-29 17:39:49,,,,2025-06-29 17:39:49
+/v/kKKw24,2,OAE-262,2025-06-29 17:39:47,2025-06-29 17:39:47,,,,2025-06-29 17:39:47
+/v/4MdG,1,SSNI-190,2025-06-29 17:39:34,2025-06-29 17:39:34,,,2025-06-29 17:39:34,
+/v/Bz1YG,1,SSNI-216,2025-06-29 17:39:32,2025-06-29 17:39:32,,,2025-06-29 17:39:32,
+/v/V4GbA,1,SSNI-240,2025-06-29 17:39:31,2025-06-29 17:39:31,,2025-06-29 17:39:31,2025-06-29 17:39:31,
+/v/V4MZz,1,SSNI-266,2025-06-29 17:39:29,2025-06-29 17:39:29,,,2025-06-29 17:39:29,
+/v/WwG3Q,1,SSNI-288,2025-06-29 17:39:28,2025-06-29 17:39:28,,,2025-06-29 17:39:28,
+/v/0eGn3,1,SSNI-309,2025-06-29 17:39:26,2025-06-29 17:39:26,,,2025-06-29 17:39:26,
+/v/EEgAd,1,SSIS-161,2025-06-29 17:39:25,2025-06-29 17:39:25,,,2025-06-29 17:39:25,
+/v/x6qxg,1,SSIS-129,2025-06-29 17:39:23,2025-06-29 17:39:23,2025-06-29 17:39:23,,2025-06-29 17:39:23,
+/v/POZPJ,1,SSIS-162,2025-06-29 17:39:22,2025-06-29 17:39:22,,,2025-06-29 17:39:22,
+/v/abZJp,1,SSIS-158,2025-06-29 17:39:20,2025-06-29 17:39:20,2025-06-29 17:39:20,,2025-06-29 17:39:20,
+/v/JpzGd,1,SSIS-194,2025-06-29 17:39:19,2025-06-29 17:39:19,2025-06-29 17:39:19,,2025-06-29 17:39:19,
+/v/1zNJw,1,SSIS-222,2025-06-29 17:39:17,2025-06-29 17:39:17,2025-06-29 17:39:17,,2025-06-29 17:39:17,
+/v/EyeR4,1,SSIS-252,2025-06-29 17:39:16,2025-06-29 17:39:16,2025-06-29 17:39:16,,,2025-06-29 17:39:16
+/v/mBm4v,1,SSIS-280,2025-06-29 17:39:14,2025-06-29 17:39:14,2025-06-29 17:39:14,,2025-06-29 17:39:14,
+/v/dXWVe,1,SSIS-308,2025-06-29 17:39:13,2025-06-29 17:39:13,2025-06-29 17:39:13,,2025-06-29 17:39:13,
+/v/b6ZDv,1,SSIS-334,2025-06-29 17:39:11,2025-06-29 17:39:11,2025-06-29 17:39:11,,2025-06-29 17:39:11,
+/v/rJ23R,1,SSIS-3611,2025-06-29 17:39:10,2025-06-29 17:39:10,2025-06-29 17:39:10,,2025-06-29 17:39:10,
+/v/RwRw4,1,SSIS-387,2025-06-29 17:39:08,2025-06-29 17:39:08,2025-06-29 17:39:08,,2025-06-29 17:39:08,
+/v/EY5kJ,1,SSIS-413,2025-06-29 17:39:07,2025-06-29 17:39:07,2025-06-29 17:39:07,,2025-06-29 17:39:07,
+/v/OP77B,1,SSIS-4404,2025-06-29 17:39:06,2025-06-29 17:39:06,2025-06-29 17:39:06,,,2025-06-29 17:39:06
+/v/0Rvnp3,1,SSIS-468,2025-06-29 17:39:04,2025-06-29 17:39:04,2025-06-29 17:39:04,,2025-06-29 17:39:04,
+/v/1BAd4d,1,SSIS-499,2025-06-29 17:39:03,2025-06-29 17:39:03,2025-06-29 17:39:03,,2025-06-29 17:39:03,
+/v/g0O1Yq,1,SSIS-531,2025-06-29 17:39:01,2025-06-29 17:39:01,2025-06-29 17:39:01,,2025-06-29 17:39:01,
+/v/W1KVxK,1,SSIS-560,2025-06-29 17:39:00,2025-06-29 17:39:00,2025-06-29 17:39:00,,2025-06-29 17:39:00,
+/v/W14M5q,1,SSIS-586,2025-06-29 17:38:58,2025-06-29 17:38:58,2025-06-29 17:38:58,,2025-06-29 17:38:58,
+/v/PQ8O7v,1,SSIS-595,2025-06-29 17:38:57,2025-06-29 17:38:57,2025-06-29 17:38:57,,2025-06-29 17:38:57,
+/v/MmEXER,1,SSIS-607,2025-06-29 17:38:55,2025-06-29 17:38:55,,2025-06-29 17:38:55,2025-06-29 17:38:55,
+/v/eKb2wp,1,SSIS-685,2025-06-29 17:38:54,2025-06-29 17:38:54,2025-06-29 17:38:54,,2025-06-29 17:38:54,
+/v/YnJMe6,1,SSIS-721,2025-06-29 17:38:52,2025-06-29 17:38:52,2025-06-29 17:38:52,,,2025-06-29 17:38:52
+/v/B8wE34,1,SSIS-762,2025-06-29 17:38:51,2025-06-29 17:38:51,2025-06-29 17:38:51,,2025-06-29 17:38:51,
+/v/MmvbqX,1,SSIS-839,2025-06-29 17:38:49,2025-06-29 17:38:49,2025-06-29 17:38:49,,2025-06-29 17:38:49,
+/v/g08yOm,1,SSIS-801,2025-06-29 17:38:48,2025-06-29 17:38:48,2025-06-29 17:38:48,,2025-06-29 17:38:48,
+/v/g0JB2Z,1,SSIS-875,2025-06-29 17:38:46,2025-06-29 17:38:46,2025-06-29 17:38:46,,2025-06-29 17:38:46,
+/v/Yn167x,1,SSIS-913,2025-06-29 17:38:45,2025-06-29 17:38:45,2025-06-29 17:38:45,,2025-06-29 17:38:45,
+/v/J2QAg3,1,SSIS-951,2025-06-29 17:38:43,2025-06-29 17:38:43,2025-06-29 17:38:43,,2025-06-29 17:38:43,
+/v/1BnXvw,1,SSIS-984,2025-06-29 17:38:42,2025-06-29 17:38:42,2025-06-29 17:38:42,,2025-06-29 17:38:42,
+/v/qD5Ew6,1,SONE-027,2025-06-29 17:38:40,2025-06-29 17:38:40,2025-06-29 17:38:40,,2025-06-29 17:38:40,
+/v/K4zV5m,1,SONE-071,2025-06-29 17:38:39,2025-06-29 17:38:39,2025-06-29 17:38:39,,2025-06-29 17:38:39,
+/v/bKAA06,1,SONE-118,2025-06-29 17:38:37,2025-06-29 17:38:37,2025-06-29 17:38:37,,2025-06-29 17:38:37,
+/v/Ww1yPp,1,SONE-153,2025-06-29 17:38:36,2025-06-29 17:38:36,2025-06-29 17:38:36,,2025-06-29 17:38:36,
+/v/GZMEbD,1,SONE-2001,2025-06-29 17:38:34,2025-06-29 17:38:34,2025-06-29 17:38:34,,2025-06-29 17:38:34,
+/v/4D5B1v,1,SONE-228,2025-06-29 17:38:33,2025-06-29 17:38:33,2025-06-29 17:38:33,,2025-06-29 17:38:33,
+/v/4D5XME,1,SONE-266,2025-06-29 17:38:32,2025-06-29 17:38:32,2025-06-29 17:38:32,,2025-06-29 17:38:32,
+/v/GZZdZ7,1,SONE-311,2025-06-29 17:38:30,2025-06-29 17:38:30,2025-06-29 17:38:30,,2025-06-29 17:38:30,
+/v/QNN9e4,1,SONE-360,2025-06-29 17:38:29,2025-06-29 17:38:29,2025-06-29 17:38:29,,2025-06-29 17:38:29,
+/v/QNNmQp,1,SONE-405,2025-06-29 17:38:27,2025-06-29 17:38:27,2025-06-29 17:38:27,,2025-06-29 17:38:27,
+/v/veeE4G,1,SONE-454,2025-06-29 17:38:26,2025-06-29 17:38:26,2025-06-29 17:38:26,,2025-06-29 17:38:26,
+/v/Yww4d6,1,SONE-499,2025-06-29 17:38:24,2025-06-29 17:38:24,2025-06-29 17:38:24,,2025-06-29 17:38:24,
+/v/6dDJKQ,1,SIVR-394,2025-06-29 17:38:23,2025-06-29 17:38:23,,,2025-06-29 17:38:23,
+/v/KknQbv,1,SONE-642,2025-06-29 17:38:21,2025-06-29 17:38:21,2025-06-29 17:38:21,,2025-06-29 17:38:21,
+/v/z4M7xb,1,SONE-543,2025-06-29 17:38:20,2025-06-29 17:38:20,2025-06-29 17:38:20,,2025-06-29 17:38:20,
+/v/Ebd6k0,1,SONE-561,2025-06-29 17:38:18,2025-06-29 17:38:18,2025-06-29 17:38:18,,2025-06-29 17:38:18,
+/v/BzK0wM,1,SONE-687,2025-06-29 17:38:17,2025-06-29 17:38:17,2025-06-29 17:38:17,,2025-06-29 17:38:17,
+/v/a8BYxX,1,SONE-725,2025-06-29 17:38:15,2025-06-29 17:38:15,2025-06-29 17:38:15,,2025-06-29 17:38:15,
+/v/a8yV0p,1,SONE-763,2025-06-29 17:38:14,2025-06-29 17:38:14,2025-06-29 17:38:14,,2025-06-29 17:38:14,
+/v/4Ddxap,1,SONE-563,2025-06-29 17:38:12,2025-06-29 17:38:12,2025-06-29 17:38:12,,2025-06-29 17:38:12,
+/v/82qPRa,1,SONE-769,2025-06-29 14:30:12,2025-06-29 14:30:12,2025-06-29 14:30:12,,2025-06-29 14:30:12,
+/v/degd5M,1,SONE-741,2025-06-29 14:30:11,2025-06-29 14:30:11,2025-06-29 14:30:11,,2025-06-29 14:30:11,
+/v/yx4kqZ,1,SONE-573,2025-06-29 14:30:09,2025-06-29 14:30:09,2025-06-29 14:30:09,,2025-06-29 14:30:09,
+/v/E2Yav4,1,SONE-008,2025-06-29 14:30:02,2025-06-29 14:30:02,2025-06-29 14:30:02,,2025-06-29 14:30:02,
+/v/0ed1Av,1,START-328,2025-06-29 14:29:59,2025-06-29 14:29:59,2025-06-29 14:29:59,,2025-06-29 14:29:59,
+/v/5nXNx7,1,JUR-3403,2025-06-29 14:29:56,2025-06-29 14:29:56,2025-06-29 14:29:56,,2025-06-29 14:29:56,
+/v/ZNdxb8,1,DASS-651,2025-06-29 14:29:43,2025-06-29 14:29:43,2025-06-29 14:29:43,,2025-06-29 14:29:43,
+/v/pkqe09,1,DASS-650,2025-06-29 14:29:41,2025-06-29 14:29:41,2025-06-29 14:29:41,,2025-06-29 14:29:41,
+/v/yx45qW,1,START-339,2025-06-29 14:29:40,2025-06-29 14:29:40,2025-06-29 14:29:40,,2025-06-29 14:29:40,

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ This feature implements automatic marking of downloaded torrents in daily report
 
 ### Enhanced History Format
 
-The history CSV file now uses an enhanced format:
+The history CSV file now uses an enhanced format with individual columns for each torrent type:
 
 **Old Format:**
 ```
@@ -320,11 +320,15 @@ href,phase,video_code,parsed_date,torrent_type
 
 **New Format:**
 ```
-href,phase,video_code,create_date,update_date,torrent_type
+href,phase,video_code,create_date,update_date,hacked_subtitle,hacked_no_subtitle,subtitle,no_subtitle
 ```
 
 - `create_date`: When the movie was first discovered and logged
 - `update_date`: When the movie was last updated with new torrent types
+- `hacked_subtitle`: Download date for hacked version with subtitles (empty if not downloaded)
+- `hacked_no_subtitle`: Download date for hacked version without subtitles (empty if not downloaded)
+- `subtitle`: Download date for subtitle version (empty if not downloaded)
+- `no_subtitle`: Download date for regular version (empty if not downloaded)
 - Backward compatibility is maintained for existing files
 
 ### Workflow
@@ -352,8 +356,8 @@ href,video_code,hacked_subtitle,subtitle
 
 **History File Format:**
 ```
-href,phase,video_code,create_date,update_date,torrent_type
-/v/mOJnXY,1,IPZZ-574,2025-07-09 20:00:57,2025-07-09 20:05:30,"hacked_subtitle,subtitle"
+href,phase,video_code,create_date,update_date,hacked_subtitle,hacked_no_subtitle,subtitle,no_subtitle
+/v/mOJnXY,1,IPZZ-574,2025-07-09 20:00:57,2025-07-09 20:05:30,2025-07-09 20:05:30,,2025-07-09 20:05:30,
 ```
 
 **Uploader Log:**


### PR DESCRIPTION
Updates the history CSV file format to use individual columns for each torrent type (hacked_subtitle, hacked_no_subtitle, subtitle, no_subtitle) instead of a single comma-separated string.

This change improves data handling and provides more flexibility. It also maintains backward compatibility with existing history files.