### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,8 @@
 # - Code is pushed to main/master branch
 
 name: Unit Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/5](https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/5)

In general, to fix this issue you add a `permissions` block either at the workflow root (applies to all jobs) or on each job, setting the minimal required scopes. For a test-and-lint workflow that only checks out code and uploads coverage via Codecov, `contents: read` is typically sufficient, because no step modifies repository contents or GitHub resources.

The best way here without changing functionality is to define a workflow-wide `permissions` block just under `name: Unit Tests`. That block should set `contents: read`, which allows `actions/checkout` to fetch source but denies write actions. Unless there is a demonstrated need for additional scopes (like `statuses` or `pull-requests` write), they should not be granted.

Concretely: edit `.github/workflows/unit-tests.yml` and insert:

```yaml
permissions:
  contents: read
```

after line 6 (`name: Unit Tests`). No imports or extra definitions are needed; `permissions` is a native GitHub Actions workflow key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
