### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-branch-check.yml
+++ b/.github/workflows/pr-branch-check.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-branch:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     # Only check PRs targeting main or master
     if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master'


### PR DESCRIPTION
Potential fix for [https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/3](https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the top level or for the specific job) that grants only the scopes needed. This avoids relying on repository/org defaults, which may be overly permissive, and aligns with the principle of least privilege.

Concretely for this workflow, the `check-branch` job needs to: (1) read pull request metadata, (2) post a comment on the pull request, and (3) update (close) the pull request. These operations require `pull-requests: write`. While `issues.createComment` is used to comment on a PR, GitHub’s token matrix allows PR comments under the `pull-requests` scope; we do not need broad `contents: write`. Therefore, the best minimal change is to add `permissions: pull-requests: write` at the job level under `check-branch`. This keeps the change local to the flagged job and does not alter other workflows.

You should edit `.github/workflows/pr-branch-check.yml` and insert a `permissions:` block under `check-branch`, between the job name and `runs-on`, like:

```yaml
  check-branch:
    permissions:
      pull-requests: write
    runs-on: ubuntu-latest
```

No additional imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
