### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,9 @@ on:
       - 'docker/**'
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+
 env:
   REGISTRY_IMAGE: javdb-autospider
 


### PR DESCRIPTION
Potential fix for [https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/2](https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/2)

In general, the fix is to declare an explicit `permissions:` block so the `GITHUB_TOKEN` used by this workflow has the least privileges necessary. Since this workflow only needs to read repository contents (for checkout and computing Docker metadata) and does not push code, create releases, or modify issues/PRs, we can restrict it to `contents: read`.

The best way to do this without changing functionality is to add a top-level `permissions:` block (at the same indentation as `on:` and `env:`) so it applies to all jobs in this workflow. We’ll set it to:

```yaml
permissions:
  contents: read
```

This should be inserted after the `on:` block (around line 24–26) or before `env:`. No other code or steps need to change, and no additional imports or actions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
