### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -16,6 +16,8 @@ jobs:
     name: Push Docker image to Docker Hub
     if: false  # DISABLED: Set to 'true' or remove this line to re-enable
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/1](https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/1)

In general, to fix this kind of issue you add a `permissions` block either at the workflow root (applies to all jobs) or under the specific job. You configure it to grant only the minimum required scopes, most commonly `contents: read` when a job only needs to read the repo (e.g., `actions/checkout`) and does not need to modify GitHub resources.

For this workflow, the safest single change is to add a job‑level `permissions` block under `push_to_registry` that restricts `GITHUB_TOKEN` to read‑only contents. None of the steps require write access to the repository or other GitHub resources: they use `actions/checkout`, Docker actions, and an action that talks to Docker Hub using explicit credentials. The only interaction with GitHub APIs beyond checkout is the cache configuration `type=gha`, which works with `contents: read`. Therefore, we can add:

```yaml
permissions:
  contents: read
```

indented correctly under the job (after `runs-on` is a typical place). No imports or code changes elsewhere are necessary; this is purely a YAML configuration update in `.github/workflows/docker-publish-dockerhub.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
