### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,5 +1,8 @@
 name: Docker Image Functional Testing
 
+permissions:
+  contents: read
+
 # This workflow focuses on comprehensive functional testing of the Docker image.
 # For multi-platform build verification, see docker-build.yml
 


### PR DESCRIPTION
Potential fix for [https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/4](https://github.com/TongWu/JAVDB_AutoSpider/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions:` block that restricts the GITHUB_TOKEN to the minimal rights needed. For this workflow, the jobs only need to read the repository contents to check out code; they do not need to write to the repo or other resources. Therefore `contents: read` at the workflow root is sufficient and applies to all jobs.

The best, least intrusive fix is to add a top-level `permissions:` block immediately under the `name:` (before `on:`) in `.github/workflows/docker-test.yml`. This will set default permissions for all jobs in this workflow, including the `test` job. No changes to steps, actions versions, or behavior are required. The token will still be usable for reading repository content via `actions/checkout`, but cannot perform write operations.

Concretely:
- Edit `.github/workflows/docker-test.yml`.
- After line 1 (`name: Docker Image Functional Testing`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- No new methods, imports, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
