### PR TITLE
Release workflow docker tags

### DIFF
--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -53,7 +53,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Fix Docker build failure on release tags by conditionally generating SHA tags with a valid prefix.

The previous configuration `type=sha,prefix={{branch}}-` resulted in an invalid Docker tag (`:-<sha>`) when the workflow was triggered by a release tag, as `{{branch}}` was empty. This change ensures SHA tags use a valid `sha-` prefix and are only generated for non-tag events.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb681fe3-0af6-460e-98da-fa08d0db46d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb681fe3-0af6-460e-98da-fa08d0db46d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

