### PR TITLE
fix: disable SHA tag for release events to avoid invalid docker tag format

### DIFF
--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -53,7 +53,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
When triggered by a tag/release event, the {{branch}} variable is empty, causing the sha tag to become '-<sha>' which is invalid (starts with hyphen).

Fix: Only generate SHA tags for branch push events, not for tag/release events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix GHCR tagging in workflow**
> 
> - Updates `docker/metadata-action` config in `docker-publish-ghcr.yml` to generate `sha-<sha>` tags only for branch pushes, disabling SHA tags on tag/release events to avoid invalid tags that start with a hyphen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5c6e5a1b06cdb8fe70524ae28603cddb2397a6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image tagging configuration to apply version prefixes only for non-tag builds when publishing to the container registry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->