### PR TITLE
fix: disable SHA tag for release events to avoid invalid docker tag format

### DIFF
--- a/.github/workflows/DailyIngestion.yml
+++ b/.github/workflows/DailyIngestion.yml
@@ -14,9 +14,9 @@ on:
         options:
           - 'ubuntu-latest'
           - 'self-hosted'
-  schedule:
+  # schedule: # DISABLED FOR PUBLIC REPO
     # Run daily at 10:00 UTC (18:00 Beijing Time)
-    - cron: '0 10 * * *'
+    # - cron: '0 10 * * *'
 
 jobs:
   # =============================================================================

--- a/.github/workflows/QBFileFilter.yml
+++ b/.github/workflows/QBFileFilter.yml
@@ -27,10 +27,10 @@ on:
         required: false
         type: boolean
         default: true
-  schedule:
+  # schedule: # DISABLED FOR PUBLIC REPO
     # Run 2 hours after DailyIngestion (which runs at 10:00 UTC)
     # This allows time for qBittorrent to fetch torrent metadata
-    - cron: '0 */6 * * *'
+    # - cron: '0 */6 * * *'
 
 jobs:
   # =============================================================================

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -1,16 +1,16 @@
 name: Publish to GitHub Container Registry
 
 on:
-  # push:  # DISABLED FOR PRIVATE REPO - enabled in public repo
-  #   branches:
-  #     - main
-  #     - master
-  #   tags:
-  #     - 'v*.*.*'
-  #   paths:
-  #     - '**.py'
-  #     - 'pytest.ini'
-  #     - 'docker/**'
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*.*.*'
+    paths:
+      - '**.py'
+      - 'pytest.ini'
+      - 'docker/**'
   workflow_dispatch:  # Allow manual trigger
 
 env:


### PR DESCRIPTION
When triggered by a tag/release event, the {{branch}} variable is empty,
causing the sha tag to become '-<sha>' which is invalid (starts with hyphen).

Fix: Only generate SHA tags for branch push events, not for tag/release events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI/CD updates**
> 
> - Adjusts GHCR metadata tags: use `type=sha,prefix=sha-` and enable only for non-tag refs to avoid invalid tags on releases
> - Enables `push` triggers (branches `main`/`master`, `v*.*.*` tags, selected paths) for `docker-publish-ghcr.yml`
> - Disables scheduled triggers (commented out) for `DailyIngestion.yml` and `QBFileFilter.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1591f9067ef8db67b6a92d58ac23423724a0c88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated scheduling for ingestion and file filter workflows; manual dispatch now required.
  * Re-enabled automatic Docker image publishing on code pushes with updated tagging logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->